### PR TITLE
feat(generate): wire up form to api and handle results

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-@AGENTS.md

--- a/app/generate/page.tsx
+++ b/app/generate/page.tsx
@@ -2,9 +2,15 @@
 
 import * as React from "react";
 import Link from "next/link";
-import { Card, CardContent } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Separator } from "@/components/ui/separator";
+import { ArrowLeft, PackagePlus, RefreshCcw } from "lucide-react";
 import {
   GoReleaseForm,
   INITIAL_GO_RELEASE_DATA,
@@ -16,6 +22,9 @@ import {
   type NpmWrapperFormData,
 } from "@/components/forms/npm-wrapper-form";
 import { cn } from "@/lib/utils";
+import { useRouter } from "next/navigation";
+import { generatePackage } from "@/lib/api";
+import { mapPlatform, mapPlatformsList } from "@/lib/platforms";
 
 type ActiveForm = "go-release" | "npm-wrapper";
 
@@ -33,6 +42,7 @@ const FORM_OPTIONS: { id: ActiveForm; label: string; description: string }[] = [
 ];
 
 export default function GeneratePage() {
+  const router = useRouter();
   const [activeForm, setActiveForm] = React.useState<ActiveForm>("go-release");
   const [goData, setGoData] = React.useState<GoReleaseFormData>(
     INITIAL_GO_RELEASE_DATA
@@ -41,89 +51,129 @@ export default function GeneratePage() {
     INITIAL_NPM_WRAPPER_DATA
   );
 
+  const [isGenerating, setIsGenerating] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
   const handleReset = () => {
     if (activeForm === "go-release") {
       setGoData(INITIAL_GO_RELEASE_DATA);
     } else {
       setNpmData(INITIAL_NPM_WRAPPER_DATA);
     }
+    setError(null);
   };
 
-  const handleGenerate = () => {
-    // Placeholder for API integration
-    const payload = activeForm === "go-release" ? goData : npmData;
-    console.log("Generating zip with:", { type: activeForm, ...payload });
+  const handleGenerate = async () => {
+    setError(null);
+    setIsGenerating(true);
+
+    try {
+      let payload;
+      if (activeForm === "go-release") {
+        payload = {
+          repo_url: goData.repoUrl,
+          binary_name: goData.binaryName,
+          platforms: mapPlatformsList(goData.platforms),
+          features: {
+            npm_wrapper: false,
+            goreleaser: true,
+            github_actions: true,
+          },
+        };
+      } else {
+        // filter out asset urls that are not in the selected platforms
+        const filteredUrls: Record<string, string> = {};
+        npmData.platforms.forEach((p) => {
+          filteredUrls[mapPlatform(p)] = npmData.assetUrls[p] || "";
+        });
+
+        payload = {
+          repo_url: npmData.repoUrl,
+          binary_name: npmData.cliCommandName,
+          version: npmData.version,
+          platforms: mapPlatformsList(npmData.platforms),
+          mode: "manual",
+          features: {
+            npm_wrapper: true,
+            goreleaser: false,
+            github_actions: false,
+          },
+          asset_urls: filteredUrls,
+        };
+      }
+
+      const result = await generatePackage(payload);
+
+      const sessionData = {
+        workflow: activeForm,
+        summary: payload,
+        files: result.files,
+      };
+
+      sessionStorage.setItem("generated-result", JSON.stringify(sessionData));
+      router.push("/result");
+    } catch (err: any) {
+      setError(err.message || "Failed to generate package");
+    } finally {
+      setIsGenerating(false);
+    }
   };
 
   return (
-    <div className="relative flex min-h-screen flex-col items-center overflow-hidden bg-[#050505] font-sans selection:bg-zinc-800">
-      {/* Background Lighting — matches hero */}
-      <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(ellipse_at_30%_20%,_rgba(255,255,255,0.04)_0%,_transparent_50%,_rgba(0,0,0,0.9)_100%)]" />
-
-      {/* Page Content */}
-     <div className="z-10 flex w-full max-w-6xl flex-col px-6 py-10 sm:px-8 md:px-12 md:py-16">
-        {/* Back Link */}
-        <Link
-          href="/"
-          className="group mb-12 inline-flex w-fit items-center gap-2 text-sm text-zinc-500 transition-colors hover:text-white"
-        >
-          <svg
-            className="h-4 w-4 transition-transform group-hover:-translate-x-0.5"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M19 12H5M12 19l-7-7 7-7"
-            />
-          </svg>
+    <div className="relative min-h-screen bg-[#09090b] text-zinc-50 font-sans selection:bg-zinc-800 flex flex-col items-center py-12 px-6">
+      
+      {/* Back Link (Absolute Top Left) */}
+      <div className="absolute top-6 left-6 md:top-8 md:left-8 z-20">
+        <Link href="/" className="inline-flex items-center gap-2 text-sm text-zinc-500 hover:text-white transition-colors">
+          <ArrowLeft className="w-4 h-4" />
           Back to home
         </Link>
+      </div>
 
+      <div className="w-full max-w-3xl space-y-8 z-10 relative mt-4 md:mt-8">
         {/* Page Header */}
-        <header className="mb-10">
-          <h1 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+        <div className="text-center space-y-3 pb-4">
+          <h1 className="text-3xl font-medium tracking-tight text-white">
             Generate your package
           </h1>
-          <p className="mt-3 max-w-xl text-base leading-relaxed text-zinc-400 sm:text-lg">
-            Choose your workflow and fill in the required details to generate the
-            wrapper zip.
+          <p className="text-zinc-400 text-sm max-w-xl mx-auto">
+            Choose your workflow and fill in the required details to generate the wrapper zip.
           </p>
-        </header>
+        </div>
 
         {/* Form Selector */}
-        <div className="mb-8 grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           {FORM_OPTIONS.map((option) => {
             const isActive = activeForm === option.id;
             return (
               <button
                 key={option.id}
                 type="button"
-                onClick={() => setActiveForm(option.id)}
+                disabled={isGenerating}
+                onClick={() => {
+                  setActiveForm(option.id);
+                  setError(null);
+                }}
                 className={cn(
-                  "group relative flex flex-col items-start rounded-xl border px-5 py-4 text-left transition-all cursor-pointer sm:px-6 sm:py-5",
+                  "group relative flex flex-col items-start rounded-xl border px-6 py-5 text-left transition-all cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed",
                   isActive
-                    ? "border-white/20 bg-white/[0.06] shadow-[0_0_30px_-10px_rgba(255,255,255,0.15)]"
+                    ? "border-white/20 bg-white/[0.06] shadow-sm"
                     : "border-white/[0.08] bg-white/[0.02] hover:border-white/15 hover:bg-white/[0.04]"
                 )}
               >
-                {/* Active Indicator Dot */}
                 <div className="mb-3 flex items-center gap-2.5">
                   <div
                     className={cn(
-                      "h-2.5 w-2.5 rounded-full border transition-all",
+                      "h-2 w-2 rounded-full transition-all",
                       isActive
-                        ? "border-white bg-white shadow-[0_0_8px_rgba(255,255,255,0.6)]"
-                        : "border-zinc-600 bg-transparent"
+                        ? "bg-emerald-500"
+                        : "bg-zinc-600 group-hover:bg-zinc-500"
                     )}
                   />
                   <span
                     className={cn(
-                      "text-sm font-semibold tracking-tight transition-colors",
-                      isActive ? "text-white" : "text-zinc-400"
+                      "text-sm font-medium tracking-tight transition-colors",
+                      isActive ? "text-white" : "text-zinc-400 group-hover:text-zinc-300"
                     )}
                   >
                     {option.label}
@@ -131,8 +181,8 @@ export default function GeneratePage() {
                 </div>
                 <p
                   className={cn(
-                    "text-[13px] leading-relaxed transition-colors",
-                    isActive ? "text-zinc-400" : "text-zinc-600"
+                    "text-xs leading-relaxed transition-colors",
+                    isActive ? "text-zinc-400" : "text-zinc-500 group-hover:text-zinc-400"
                   )}
                 >
                   {option.description}
@@ -142,58 +192,21 @@ export default function GeneratePage() {
           })}
         </div>
 
-        {/* Form Card */}
-        <Card className="mb-8">
-          <CardContent className="p-6 sm:p-8">
-            {/* Form Header inside card */}
-            <div className="mb-6 flex items-center gap-3">
-              <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-white/10 bg-white/5">
-                {activeForm === "go-release" ? (
-                  <svg
-                    className="h-4 w-4 text-zinc-300"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={1.5}
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M17.25 6.75L22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3l-4.5 16.5"
-                    />
-                  </svg>
-                ) : (
-                  <svg
-                    className="h-4 w-4 text-zinc-300"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={1.5}
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9"
-                    />
-                  </svg>
-                )}
-              </div>
-              <div>
-                <h2 className="text-sm font-semibold text-white">
-                  {activeForm === "go-release"
-                    ? "Go Release Configuration"
-                    : "NPM Wrapper Configuration"}
-                </h2>
-                <p className="text-xs text-zinc-500">
-                  {activeForm === "go-release"
-                    ? "Configure your Go binary packaging"
-                    : "Set up the npm wrapper package"}
-                </p>
-              </div>
-            </div>
-
-            <Separator className="mb-8" />
-
+        {/* Form Card Configuration */}
+        <Card className={cn(isGenerating && "opacity-60 pointer-events-none")}>
+          <CardHeader>
+            <CardTitle>
+              {activeForm === "go-release"
+                ? "Go Release Configuration"
+                : "NPM Wrapper Configuration"}
+            </CardTitle>
+            <CardDescription>
+              {activeForm === "go-release"
+                ? "Configure your Go binary packaging details."
+                : "Specify registry setup for the npm wrapper package."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
             {/* Active Form */}
             {activeForm === "go-release" ? (
               <GoReleaseForm data={goData} onChange={setGoData} />
@@ -203,26 +216,28 @@ export default function GeneratePage() {
           </CardContent>
         </Card>
 
-        {/* Action Buttons */}
-        <div className="flex flex-col-reverse items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end">
-          <Button variant="secondary" size="default" onClick={handleReset}>
+        {/* Error Message */}
+        {error && (
+          <div className="rounded-md bg-red-500/10 px-4 py-3 border border-red-500/20 text-sm text-red-400">
+            {error}
+          </div>
+        )}
+
+        {/* Action Buttons at the Bottom */}
+        <div className="flex flex-col-reverse items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end pt-4">
+          <Button variant="secondary" size="sm" className="w-full sm:w-auto gap-2" onClick={handleReset} disabled={isGenerating}>
+            <RefreshCcw className="w-3.5 h-3.5 text-zinc-400" />
             Reset
           </Button>
-          <Button variant="primary" size="default" onClick={handleGenerate}>
-            <svg
-              className="h-4 w-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
-              />
-            </svg>
-            Generate Zip
+          <Button variant="primary" size="sm" className="w-full sm:w-auto gap-2" onClick={handleGenerate} disabled={isGenerating}>
+            {isGenerating ? (
+              <>Generating...</>
+            ) : (
+              <>
+                <PackagePlus className="w-4 h-4" />
+                Generate ZIP
+              </>
+            )}
           </Button>
         </div>
       </div>

--- a/app/result/page.tsx
+++ b/app/result/page.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { Editor } from "@monaco-editor/react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { ArrowLeft, Download, Copy, FileCode2, Check, DownloadCloud, Code2 } from "lucide-react";
+import Link from "next/link";
+
+interface SessionData {
+  workflow: "go-release" | "npm-wrapper";
+  summary: {
+    repo_url: string;
+    binary_name: string;
+    version?: string;
+    platforms: string[];
+    asset_urls?: Record<string, string>;
+    [key: string]: any;
+  };
+  files: Record<string, string>;
+}
+
+const getLanguage = (filename: string) => {
+  const ext = filename.split(".").pop()?.toLowerCase();
+  switch (ext) {
+    case "json":
+      return "json";
+    case "js":
+    case "ts":
+      return "javascript";
+    case "md":
+      return "markdown";
+    case "yml":
+    case "yaml":
+      return "yaml";
+    default:
+      return "plaintext";
+  }
+};
+
+export default function ResultPage() {
+  const [resultData, setResultData] = useState<SessionData | null>(null);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [activeFile, setActiveFile] = useState<string>("");
+  const [fileContents, setFileContents] = useState<Record<string, string>>({});
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    const raw = sessionStorage.getItem("generated-result");
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as SessionData;
+        setResultData(parsed);
+        setFileContents(parsed.files);
+        const keys = Object.keys(parsed.files);
+        if (keys.length > 0) {
+          setActiveFile(keys[0]);
+        }
+      } catch (err) {
+        console.error("Failed to parse session data", err);
+      }
+    }
+    setIsLoaded(true);
+  }, []);
+
+  const handleEditorChange = (value: string | undefined) => {
+    if (value !== undefined) {
+      setFileContents((prev) => ({ ...prev, [activeFile]: value }));
+    }
+  };
+
+  const handleCopy = () => {
+    if (!fileContents[activeFile]) return;
+    navigator.clipboard.writeText(fileContents[activeFile]);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  if (!isLoaded) {
+    return (
+      <div className="min-h-screen bg-[#09090b] text-zinc-50 flex items-center justify-center font-sans">
+        <div className="text-zinc-500 text-sm">Loading workspace...</div>
+      </div>
+    );
+  }
+
+  if (!resultData) {
+    return (
+      <div className="min-h-screen bg-[#09090b] text-zinc-50 flex flex-col items-center justify-center font-sans gap-6">
+        <p className="text-zinc-400 text-sm">No generated result found. Go back and generate a package first.</p>
+        <Link href="/generate">
+          <Button variant="primary" size="sm">Go to Generate</Button>
+        </Link>
+      </div>
+    );
+  }
+
+  const isNpmWrapper = resultData.workflow === "npm-wrapper";
+
+  return (
+    <div className="min-h-screen bg-[#09090b] text-zinc-50 font-sans selection:bg-zinc-800">
+      {/* Top Navbar Actions */}
+      <div className="flex items-center justify-between border-b border-white/[0.08] px-6 py-4 bg-[#09090b]">
+        <Link href="/generate" className="inline-flex">
+          <Button variant="ghost" size="sm" className="gap-2 text-zinc-400 hover:text-white">
+            <ArrowLeft className="w-4 h-4" />
+            Back to edit
+          </Button>
+        </Link>
+        <Button variant="primary" size="sm" className="gap-2">
+          <DownloadCloud className="w-4 h-4" />
+          Download ZIP
+        </Button>
+      </div>
+
+      <div className="max-w-7xl mx-auto p-6 lg:p-8 space-y-8">
+        {/* Header Section */}
+        <div className="flex flex-col md:flex-row md:items-end justify-between gap-6">
+          <div className="space-y-2">
+            <h1 className="text-3xl font-medium tracking-tight text-white">Generated Output</h1>
+            <p className="text-zinc-400 text-sm">Review, edit, and copy your generated files</p>
+          </div>
+          <div className="inline-flex items-center gap-2 rounded-full border border-white/[0.08] bg-white/[0.02] px-3 py-1 text-sm font-medium text-zinc-300">
+            <div className="h-2 w-2 rounded-full bg-emerald-500 animate-pulse" />
+            Workflow: {isNpmWrapper ? "NPM Wrapper" : "Go Release"}
+          </div>
+        </div>
+
+        {/* Main 2-Column Grid */}
+        <div className="grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-6 items-start">
+
+          {/* Left Panel - Input Summary */}
+          <Card className="sticky top-6">
+            <CardHeader>
+              <CardTitle>Input Summary</CardTitle>
+              <CardDescription>Values used for generation</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="space-y-1">
+                <p className="text-xs font-medium text-zinc-500 uppercase tracking-wider">Repository URL</p>
+                <p className="text-sm font-mono text-zinc-300 truncate" title={resultData.summary.repo_url}>
+                  {resultData.summary.repo_url || "N/A"}
+                </p>
+              </div>
+
+              <div className="space-y-1">
+                <p className="text-xs font-medium text-zinc-500 uppercase tracking-wider">Binary Name</p>
+                <div className="inline-flex items-center gap-2 rounded-md bg-white/[0.04] px-2 py-1">
+                  <Code2 className="w-4 h-4 text-zinc-400" />
+                  <span className="text-sm font-mono text-zinc-200">{resultData.summary.binary_name || "N/A"}</span>
+                </div>
+              </div>
+
+              {isNpmWrapper && resultData.summary.version && (
+                <div className="space-y-1">
+                  <p className="text-xs font-medium text-zinc-500 uppercase tracking-wider">Version</p>
+                  <p className="text-sm font-mono text-zinc-300">{resultData.summary.version}</p>
+                </div>
+              )}
+
+              <Separator className="bg-white/[0.08]" />
+
+              <div className="space-y-2">
+                <p className="text-xs font-medium text-zinc-500 uppercase tracking-wider">Target Platforms ({resultData.summary.platforms?.length || 0})</p>
+                <div className="flex flex-wrap gap-2">
+                  {resultData.summary.platforms?.map((platform) => (
+                    <span key={platform} className="text-xs font-mono rounded bg-white/[0.04] border border-white/[0.08] px-2 py-1 text-zinc-300">
+                      {platform}
+                    </span>
+                  ))}
+                </div>
+              </div>
+
+              {/* Display Asset URLs if NPM wrapper workflow and asset_urls exist */}
+              {isNpmWrapper && resultData.summary.asset_urls && Object.keys(resultData.summary.asset_urls).length > 0 && (
+                <>
+                  <Separator className="bg-white/[0.08]" />
+                  <div className="space-y-2">
+                    <p className="text-xs font-medium text-zinc-500 uppercase tracking-wider">Asset URLs</p>
+                    <div className="space-y-2">
+                      {Object.entries(resultData.summary.asset_urls).map(([key, url]) => (
+                        <div key={key} className="space-y-1">
+                          <p className="text-[10px] text-zinc-500 uppercase">{key}</p>
+                          <p className="text-xs font-mono text-zinc-300 truncate" title={url as string}>
+                            {url as string || "None provided"}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </>
+              )}
+
+            </CardContent>
+          </Card>
+
+          {/* Right Panel - Workspace */}
+          <div className="flex flex-col lg:flex-row h-[70vh] min-h-[600px] rounded-xl border border-white/[0.08] bg-[#0c0c0e] overflow-hidden shadow-2xl">
+
+            {/* File Explorer Sidebar */}
+            <div className="w-full lg:w-64 border-r border-white/[0.08] flex flex-col bg-[#09090b]">
+              <div className="px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wider border-b border-white/[0.08] flex items-center justify-between">
+                <span>Explorer</span>
+              </div>
+              <div className="flex-1 overflow-y-auto py-2">
+                <div className="px-2 pb-1">
+                  <div className="px-2 py-1 text-xs font-medium text-zinc-400 flex items-center gap-1.5 opacity-80">
+                    <ChevronDownIcon className="w-3.5 h-3.5" />
+                    generated
+                  </div>
+                  <div className="mt-1 space-y-0.5">
+                    {Object.keys(resultData.files || {}).map((filename) => (
+                      <button
+                        key={filename}
+                        onClick={() => setActiveFile(filename)}
+                        className={`w-full flex items-center gap-2 px-6 py-1.5 text-sm transition-colors ${activeFile === filename
+                          ? "bg-white/[0.08] text-white"
+                          : "text-zinc-400 hover:bg-white/[0.04] hover:text-zinc-200"
+                          }`}
+                      >
+                        <FileCode2 className={`w-4 h-4 ${activeFile === filename ? "text-emerald-400" : "text-zinc-500"}`} />
+                        <span className="truncate">{filename}</span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Editor Content Area */}
+            <div className="flex-1 flex flex-col min-w-0 bg-[#0c0c0e] relative">
+              <div className="flex items-center justify-between px-4 py-2 border-b border-white/[0.08] bg-[#09090b]">
+                <div className="flex items-center gap-2 text-sm text-zinc-300 px-3 py-1.5 bg-white/[0.04] rounded-md border border-white/[0.04]">
+                  <FileCode2 className="w-4 h-4 text-emerald-400" />
+                  {activeFile || "Select a file"}
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 gap-2 text-zinc-400 hover:text-white"
+                    onClick={handleCopy}
+                    disabled={!activeFile}
+                  >
+                    {copied ? <Check className="w-3.5 h-3.5 text-emerald-400" /> : <Copy className="w-3.5 h-3.5" />}
+                    {copied ? "Copied" : "Copy"}
+                  </Button>
+                  <Button variant="ghost" size="sm" className="h-8 gap-2 text-zinc-400 hover:text-white" disabled>
+                    <Download className="w-3.5 h-3.5" />
+                    <span className="sr-only sm:not-sr-only">Download File</span>
+                  </Button>
+                </div>
+              </div>
+
+              <div className="flex-1 w-full relative">
+                {activeFile ? (
+                  <Editor
+                    height="100%"
+                    language={getLanguage(activeFile)}
+                    theme="vs-dark"
+                    value={fileContents[activeFile] || ""}
+                    onChange={handleEditorChange}
+                    options={{
+                      minimap: { enabled: false },
+                      fontSize: 14,
+                      lineHeight: 1.6,
+                      padding: { top: 24, bottom: 24 },
+                      scrollBeyondLastLine: false,
+                      smoothScrolling: true,
+                      cursorBlinking: "smooth",
+                      fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', Consolas, monospace",
+                    }}
+                    className="absolute inset-0"
+                    loading={
+                      <div className="flex items-center justify-center h-full text-zinc-500 text-sm">
+                        Loading editor...
+                      </div>
+                    }
+                  />
+                ) : (
+                  <div className="flex items-center justify-center h-full text-zinc-500 text-sm">
+                    No file selected
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ChevronDownIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      {...props}
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}

--- a/components/forms/go-release-form.tsx
+++ b/components/forms/go-release-form.tsx
@@ -1,80 +1,80 @@
 "use client";
 
-import * as React from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
-import { Select, SelectOption } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
 
 const PLATFORMS = [
-  { id: "linux", label: "Linux" },
-  { id: "darwin", label: "macOS" },
-  { id: "windows", label: "Windows" },
+    { id: "linux", label: "Linux" },
+    { id: "darwin", label: "macOS" },
+    { id: "windows", label: "Windows" },
 ];
 
 export interface GoReleaseFormData {
-  repoUrl: string;
-  binaryName: string;
-  packageName: string;
-  description: string;
-  author: string;
-  platforms: string[];
-  notes: string;
+    repoUrl: string;
+    binaryName: string;
+    packageName: string;
+    description: string;
+    author: string;
+    platforms: string[];
+    notes: string;
 }
 
 interface GoReleaseFormProps {
-  data: GoReleaseFormData;
-  onChange: (data: GoReleaseFormData) => void;
+    data: GoReleaseFormData;
+    onChange: (data: GoReleaseFormData) => void;
 }
 
 export function GoReleaseForm({ data, onChange }: GoReleaseFormProps) {
-  const update = <K extends keyof GoReleaseFormData>(
-    key: K,
-    value: GoReleaseFormData[K]
-  ) => {
-    onChange({ ...data, [key]: value });
-  };
+    const update = <K extends keyof GoReleaseFormData>(
+        key: K,
+        value: GoReleaseFormData[K]
+    ) => {
+        onChange({ ...data, [key]: value });
+    };
 
-  const togglePlatform = (platformId: string, checked: boolean) => {
-    const next = checked
-      ? [...new Set([...data.platforms, platformId])]
-      : data.platforms.filter((p) => p !== platformId);
-    update("platforms", next);
-  };
+    const togglePlatform = (platformId: string, checked: boolean) => {
+        const next = checked
+            ? [...new Set([...data.platforms, platformId])]
+            : data.platforms.filter((p) => p !== platformId);
+        update("platforms", next);
+    };
 
-  return (
-    <div className="space-y-8">
-      {/* Main Settings */}
-      <div className="grid gap-6 sm:grid-cols-2">
-        <div className="space-y-2.5">
-          <Label htmlFor="go-repo-url">Repository URL</Label>
-          <Input
-            id="go-repo-url"
-            placeholder="github.com/user/repo"
-            value={data.repoUrl}
-            onChange={(e) => update("repoUrl", e.target.value)}
-          />
-        </div>
-        <div className="space-y-2.5">
-          <Label htmlFor="go-binary-name">Binary Name</Label>
-          <Input
-            id="go-binary-name"
-            placeholder="mytool"
-            value={data.binaryName}
-            onChange={(e) => {
-              update("binaryName", e.target.value);
-              update("packageName", e.target.value); // Sync automatically
-            }}
-          />
-        </div>
-      </div>
+    return (
+        <div className="space-y-8">
+            {/* Main Settings */}
+            <div className="grid gap-6 sm:grid-cols-2">
+                <div className="space-y-2.5">
+                    <Label htmlFor="go-repo-url">Repository URL</Label>
+                    <Input
+                        id="go-repo-url"
+                        placeholder="github.com/user/repo"
+                        value={data.repoUrl}
+                        onChange={(e) => update("repoUrl", e.target.value)}
+                    />
+                </div>
+                <div className="space-y-2.5">
+                    <Label htmlFor="go-binary-name">Binary Name</Label>
+                    <Input
+                        id="go-binary-name"
+                        placeholder="mytool"
+                        value={data.binaryName}
+                        onChange={(e) => {
+                            onChange({
+                              ...data,
+                              binaryName: e.target.value,
+                              packageName: e.target.value,
+                            });
+                        }}
+                    />
+                </div>
+            </div>
 
-      <Separator />
+            <Separator />
 
-      {/* Description & Author (Commented out for now) */}
-      {/* 
+            {/* Description & Author (Commented out for now) */}
+            {/* 
       <div className="grid gap-6 sm:grid-cols-2">
         <div className="space-y-2.5">
           <Label htmlFor="go-description">Description</Label>
@@ -97,53 +97,53 @@ export function GoReleaseForm({ data, onChange }: GoReleaseFormProps) {
       </div>
       */}
 
-      {/* Platforms */}
-      <div className="space-y-3">
-        <Label>Target Platforms</Label>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-          {PLATFORMS.map((platform) => {
-            const isChecked = data.platforms.includes(platform.id);
-            return (
-              <div
-                key={platform.id}
-                role="button"
-                tabIndex={0}
-                onClick={() => togglePlatform(platform.id, !isChecked)}
-                onKeyDown={(e) => {
-                  if (e.key === " " || e.key === "Enter") {
-                    e.preventDefault();
-                    togglePlatform(platform.id, !isChecked);
-                  }
-                }}
-                className="flex cursor-pointer items-center gap-3 rounded-lg border border-white/[0.08] bg-white/[0.02] px-3.5 py-3 transition-colors hover:border-white/20 hover:bg-white/[0.04]"
-              >
-                <Checkbox
-                  id={`go-platform-${platform.id}`}
-                  checked={isChecked}
-                  onCheckedChange={(checked) =>
-                    togglePlatform(platform.id, checked)
-                  }
-                />
-                <span className="text-sm text-zinc-300">{platform.label}</span>
-              </div>
-            );
-          })}
+            {/* Platforms */}
+            <div className="space-y-3">
+                <Label>Target Platforms</Label>
+                <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                    {PLATFORMS.map((platform) => {
+                        const isChecked = data.platforms.includes(platform.id);
+                        return (
+                            <div
+                                key={platform.id}
+                                role="button"
+                                tabIndex={0}
+                                onClick={() => togglePlatform(platform.id, !isChecked)}
+                                onKeyDown={(e) => {
+                                    if (e.key === " " || e.key === "Enter") {
+                                        e.preventDefault();
+                                        togglePlatform(platform.id, !isChecked);
+                                    }
+                                }}
+                                className="flex cursor-pointer items-center gap-3 rounded-lg border border-white/[0.08] bg-white/[0.02] px-3.5 py-3 transition-colors hover:border-white/20 hover:bg-white/[0.04]"
+                            >
+                                <Checkbox
+                                    id={`go-platform-${platform.id}`}
+                                    checked={isChecked}
+                                    onCheckedChange={(checked) =>
+                                        togglePlatform(platform.id, checked)
+                                    }
+                                />
+                                <span className="text-sm text-zinc-300">{platform.label}</span>
+                            </div>
+                        );
+                    })}
+                </div>
+            </div>
+
+            {/* Output mode section removed as requested */}
+
+            {/* Notes section removed as requested */}
         </div>
-      </div>
-
-      {/* Output mode section removed as requested */}
-
-      {/* Notes section removed as requested */}
-    </div>
-  );
+    );
 }
 
 export const INITIAL_GO_RELEASE_DATA: GoReleaseFormData = {
-  repoUrl: "",
-  binaryName: "",
-  packageName: "",
-  description: "",
-  author: "",
-  platforms: [],
-  notes: "",
+    repoUrl: "",
+    binaryName: "",
+    packageName: "",
+    description: "",
+    author: "",
+    platforms: [],
+    notes: "",
 };

--- a/components/forms/npm-wrapper-form.tsx
+++ b/components/forms/npm-wrapper-form.tsx
@@ -1,176 +1,177 @@
 "use client";
 
-import * as React from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
 
 const PLATFORMS = [
-  { id: "linux", label: "Linux" },
-  { id: "darwin", label: "macOS" },
-  { id: "windows", label: "Windows" },
+    { id: "linux", label: "Linux" },
+    { id: "darwin", label: "macOS" },
+    { id: "windows", label: "Windows" },
 ];
 
 export interface NpmWrapperFormData {
-  repoUrl: string;
-  cliCommandName: string;
-  packageName: string;
-  version: string;
-  platforms: string[];
-  assetUrls: Record<string, string>;
+    repoUrl: string;
+    cliCommandName: string;
+    packageName: string;
+    version: string;
+    platforms: string[];
+    assetUrls: Record<string, string>;
 }
 
 export const INITIAL_NPM_WRAPPER_DATA: NpmWrapperFormData = {
-  repoUrl: "",
-  cliCommandName: "",
-  packageName: "",
-  version: "",
-  platforms: [],
-  assetUrls: {},
+    repoUrl: "",
+    cliCommandName: "",
+    packageName: "",
+    version: "",
+    platforms: [],
+    assetUrls: {},
 };
 
 interface NpmWrapperFormProps {
-  data: NpmWrapperFormData;
-  onChange: (data: NpmWrapperFormData) => void;
+    data: NpmWrapperFormData;
+    onChange: (data: NpmWrapperFormData) => void;
 }
 
 export function NpmWrapperForm({ data, onChange }: NpmWrapperFormProps) {
-  const update = <K extends keyof NpmWrapperFormData>(
-    key: K,
-    value: NpmWrapperFormData[K]
-  ) => {
-    onChange({ ...data, [key]: value });
-  };
+    const update = <K extends keyof NpmWrapperFormData>(
+        key: K,
+        value: NpmWrapperFormData[K]
+    ) => {
+        onChange({ ...data, [key]: value });
+    };
 
-  const togglePlatform = (platformId: string, checked: boolean) => {
-    const nextPlatforms = checked
-      ? [...new Set([...data.platforms, platformId])]
-      : data.platforms.filter((p) => p !== platformId);
-    
-    // Only keep URLs for checked platforms
-    const nextAssetUrls = { ...data.assetUrls };
-    if (!checked) {
-      delete nextAssetUrls[platformId];
-    } else if (!nextAssetUrls[platformId]) {
-        nextAssetUrls[platformId] = "";
-    }
+    const togglePlatform = (platformId: string, checked: boolean) => {
+        const nextPlatforms = checked
+            ? [...new Set([...data.platforms, platformId])]
+            : data.platforms.filter((p) => p !== platformId);
 
-    onChange({
-      ...data,
-      platforms: nextPlatforms,
-      assetUrls: nextAssetUrls,
-    });
-  };
+        // Only keep URLs for checked platforms
+        const nextAssetUrls = { ...data.assetUrls };
+        if (!checked) {
+            delete nextAssetUrls[platformId];
+        } else if (!nextAssetUrls[platformId]) {
+            nextAssetUrls[platformId] = "";
+        }
 
-  const updateAssetUrl = (platformId: string, url: string) => {
-    update("assetUrls", { ...data.assetUrls, [platformId]: url });
-  };
+        onChange({
+            ...data,
+            platforms: nextPlatforms,
+            assetUrls: nextAssetUrls,
+        });
+    };
 
-  return (
-    <div className="space-y-8">
-      {/* Main Settings */}
-      <div className="grid gap-6 sm:grid-cols-3">
-        <div className="space-y-2.5">
-          <Label htmlFor="npm-repo-url">Repository URL</Label>
-          <Input
-            id="npm-repo-url"
-            placeholder="github.com/user/repo"
-            value={data.repoUrl || ""}
-            onChange={(e) => update("repoUrl", e.target.value)}
-          />
-        </div>
-        <div className="space-y-2.5">
-          <Label htmlFor="npm-cli-command">Binary Name</Label>
-          <Input
-            id="npm-cli-command"
-            placeholder="mytool"
-            value={data.cliCommandName}
-            onChange={(e) => {
-              update("cliCommandName", e.target.value);
-              update("packageName", e.target.value);
-            }}
-          />
-        </div>
-        <div className="space-y-2.5">
-          <Label htmlFor="npm-version">Version</Label>
-          <Input
-            id="npm-version"
-            placeholder="1.0.0"
-            value={data.version}
-            onChange={(e) => update("version", e.target.value)}
-          />
-        </div>
-      </div>
+    const updateAssetUrl = (platformId: string, url: string) => {
+        update("assetUrls", { ...data.assetUrls, [platformId]: url });
+    };
 
-      <Separator />
-
-      {/* Platforms Settings */}
-      <div className="space-y-6">
-        <div className="space-y-3">
-          <Label>Target Platforms</Label>
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-            {PLATFORMS.map((platform) => {
-              const isChecked = data.platforms.includes(platform.id);
-              return (
-                <div
-                  key={platform.id}
-                  role="button"
-                  tabIndex={0}
-                  onClick={() => togglePlatform(platform.id, !isChecked)}
-                  onKeyDown={(e) => {
-                    if (e.key === " " || e.key === "Enter") {
-                      e.preventDefault();
-                      togglePlatform(platform.id, !isChecked);
-                    }
-                  }}
-                  className={`flex cursor-pointer items-center gap-3 rounded-lg border px-3.5 py-3 transition-colors ${
-                    isChecked
-                      ? "border-white/20 bg-white/[0.06]"
-                      : "border-white/[0.08] bg-white/[0.02] hover:border-white/20 hover:bg-white/[0.04]"
-                  }`}
-                >
-                  <Checkbox
-                    id={`npm-platform-${platform.id}`}
-                    checked={isChecked}
-                    onCheckedChange={(checked) =>
-                      togglePlatform(platform.id, !!checked)
-                    }
-                  />
-                  <span className="text-sm text-zinc-300">{platform.label}</span>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-
-        {/* Dynamic Asset URLs */}
-        {data.platforms.length > 0 && (
-          <div className="space-y-4 animate-in fade-in slide-in-from-top-2 duration-300 ease-out py-2">
-            <Label className="text-zinc-400">Platform Asset URLs</Label>
-            <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
-              {PLATFORMS.filter((p) => data.platforms.includes(p.id)).map(
-                (platform) => (
-                  <div key={`asset-${platform.id}`} className="space-y-2.5">
-                    <Label
-                      htmlFor={`npm-asset-${platform.id}`}
-                      className="text-xs text-zinc-400"
-                    >
-                      {platform.label} URL
-                    </Label>
+    return (
+        <div className="space-y-8">
+            {/* Main Settings */}
+            <div className="grid gap-6 sm:grid-cols-3">
+                <div className="space-y-2.5">
+                    <Label htmlFor="npm-repo-url">Repository URL</Label>
                     <Input
-                      id={`npm-asset-${platform.id}`}
-                      placeholder={`https://.../${platform.id}-binary`}
-                      value={data.assetUrls[platform.id] || ""}
-                      onChange={(e) => updateAssetUrl(platform.id, e.target.value)}
+                        id="npm-repo-url"
+                        placeholder="github.com/user/repo"
+                        value={data.repoUrl || ""}
+                        onChange={(e) => update("repoUrl", e.target.value)}
                     />
-                  </div>
-                )
-              )}
+                </div>
+                <div className="space-y-2.5">
+                    <Label htmlFor="npm-cli-command">Binary Name</Label>
+                    <Input
+                        id="npm-cli-command"
+                        placeholder="mytool"
+                        value={data.cliCommandName}
+                        onChange={(e) => {
+                            onChange({
+                                ...data,
+                                cliCommandName: e.target.value,
+                                packageName: e.target.value,
+                            });
+                        }}
+                    />
+                </div>
+                <div className="space-y-2.5">
+                    <Label htmlFor="npm-version">Version</Label>
+                    <Input
+                        id="npm-version"
+                        placeholder="1.0.0"
+                        value={data.version}
+                        onChange={(e) => update("version", e.target.value)}
+                    />
+                </div>
             </div>
-          </div>
-        )}
-      </div>
-    </div>
-  );
+
+            <Separator />
+
+            {/* Platforms Settings */}
+            <div className="space-y-6">
+                <div className="space-y-3">
+                    <Label>Target Platforms</Label>
+                    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                        {PLATFORMS.map((platform) => {
+                            const isChecked = data.platforms.includes(platform.id);
+                            return (
+                                <div
+                                    key={platform.id}
+                                    role="button"
+                                    tabIndex={0}
+                                    onClick={() => togglePlatform(platform.id, !isChecked)}
+                                    onKeyDown={(e) => {
+                                        if (e.key === " " || e.key === "Enter") {
+                                            e.preventDefault();
+                                            togglePlatform(platform.id, !isChecked);
+                                        }
+                                    }}
+                                    className={`flex cursor-pointer items-center gap-3 rounded-lg border px-3.5 py-3 transition-colors ${isChecked
+                                        ? "border-white/20 bg-white/[0.06]"
+                                        : "border-white/[0.08] bg-white/[0.02] hover:border-white/20 hover:bg-white/[0.04]"
+                                        }`}
+                                >
+                                    <Checkbox
+                                        id={`npm-platform-${platform.id}`}
+                                        checked={isChecked}
+                                        onCheckedChange={(checked) =>
+                                            togglePlatform(platform.id, !!checked)
+                                        }
+                                    />
+                                    <span className="text-sm text-zinc-300">{platform.label}</span>
+                                </div>
+                            );
+                        })}
+                    </div>
+                </div>
+
+                {/* Dynamic Asset URLs */}
+                {data.platforms.length > 0 && (
+                    <div className="space-y-4 animate-in fade-in slide-in-from-top-2 duration-300 ease-out py-2">
+                        <Label className="text-zinc-400">Platform Asset URLs</Label>
+                        <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+                            {PLATFORMS.filter((p) => data.platforms.includes(p.id)).map(
+                                (platform) => (
+                                    <div key={`asset-${platform.id}`} className="space-y-2.5">
+                                        <Label
+                                            htmlFor={`npm-asset-${platform.id}`}
+                                            className="text-xs text-zinc-400"
+                                        >
+                                            {platform.label} URL
+                                        </Label>
+                                        <Input
+                                            id={`npm-asset-${platform.id}`}
+                                            placeholder={`https://.../${platform.id}-binary`}
+                                            value={data.assetUrls[platform.id] || ""}
+                                            onChange={(e) => updateAssetUrl(platform.id, e.target.value)}
+                                        />
+                                    </div>
+                                )
+                            )}
+                        </div>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,22 @@
+import axiosInstance from "./axios";
+
+export async function generatePackage(payload: unknown) {
+  try {
+    const response = await axiosInstance.post("/generate", payload);
+
+    return response.data;
+  } catch (error: any) {
+    if (error.response) {
+      throw new Error(
+        error.response.data?.message ||
+        "Server error while generating package"
+      );
+    }
+
+    if (error.request) {
+      throw new Error("API not reachable. Is backend running?");
+    }
+
+    throw new Error("Unexpected error occurred");
+  }
+}

--- a/lib/axios.ts
+++ b/lib/axios.ts
@@ -1,0 +1,11 @@
+import axios from "axios";
+
+const axiosInstance = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
+  headers: {
+    "Content-Type": "application/json",
+  },
+  timeout: 10000,
+});
+
+export default axiosInstance;

--- a/lib/mockOutput.ts
+++ b/lib/mockOutput.ts
@@ -1,0 +1,24 @@
+export const mockResult = {
+  workflow: "npm-wrapper",
+  summary: {
+    repo_url: "https://github.com/user/repo",
+    binary_name: "mytool",
+    version: "v1.0.0",
+    platforms: [
+      "linux-amd64",
+      "darwin-arm64",
+      "windows-amd64"
+    ],
+    asset_urls: {
+      "linux-amd64": "https://example.com/linux",
+      "darwin-arm64": "https://example.com/macos",
+      "windows-amd64": "https://example.com/windows"
+    }
+  },
+  files: {
+    "README.md": "# mytool\n\nGenerated automatically.",
+    "package.json": "{\n  \"name\": \"mytool-npm\",\n  \"version\": \"1.0.0\"\n}",
+    "index.js": "console.log('run');",
+    "install.js": "console.log('install');"
+  }
+};

--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -1,0 +1,16 @@
+export const mapPlatform = (platformId: string): string => {
+  switch (platformId) {
+    case "linux":
+      return "linux-amd64";
+    case "darwin":
+      return "darwin-arm64";
+    case "windows":
+      return "windows-amd64";
+    default:
+      return platformId;
+  }
+};
+
+export const mapPlatformsList = (platformIds: string[]): string[] => {
+  return platformIds.map(mapPlatform);
+};

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
+    "axios": "^1.15.0",
+    "lucide-react": "^1.8.0",
+    "monaco-editor": "^0.55.1",
     "next": "16.2.3",
     "react": "19.2.4",
     "react-dom": "19.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@monaco-editor/react':
+        specifier: ^4.7.0
+        version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      axios:
+        specifier: ^1.15.0
+        version: 1.15.0
+      lucide-react:
+        specifier: ^1.8.0
+        version: 1.8.0(react@19.2.4)
+      monaco-editor:
+        specifier: ^0.55.1
+        version: 0.55.1
       next:
         specifier: 16.2.3
         version: 16.2.3(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -209,89 +221,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -332,6 +360,16 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@monaco-editor/loader@1.7.0':
+    resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
+
+  '@monaco-editor/react@4.7.0':
+    resolution: {integrity: sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==}
+    peerDependencies:
+      monaco-editor: '>= 0.25.0 < 1'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -358,24 +396,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.3':
     resolution: {integrity: sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.3':
     resolution: {integrity: sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.3':
     resolution: {integrity: sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.3':
     resolution: {integrity: sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==}
@@ -449,24 +491,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -521,6 +567,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@typescript-eslint/eslint-plugin@8.58.1':
     resolution: {integrity: sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==}
@@ -620,41 +669,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -739,6 +796,9 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -746,6 +806,9 @@ packages:
   axe-core@4.11.2:
     resolution: {integrity: sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==}
     engines: {node: '>=4'}
+
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -812,6 +875,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -868,6 +935,10 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -875,6 +946,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dompurify@3.2.7:
+    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1094,9 +1168,22 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1411,24 +1498,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1460,8 +1551,18 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lucide-react@1.8.0:
+    resolution: {integrity: sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  marked@14.0.0:
+    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1475,6 +1576,14 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -1484,6 +1593,9 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  monaco-editor@0.55.1:
+    resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1622,6 +1734,10 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1738,6 +1854,9 @@ packages:
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  state-local@1.0.7:
+    resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -2207,6 +2326,17 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@monaco-editor/loader@1.7.0':
+    dependencies:
+      state-local: 1.0.7
+
+  '@monaco-editor/react@4.7.0(monaco-editor@0.55.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@monaco-editor/loader': 1.7.0
+      monaco-editor: 0.55.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.9.2
@@ -2355,6 +2485,9 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -2598,11 +2731,21 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  asynckit@0.4.0: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
 
   axe-core@4.11.2: {}
+
+  axios@1.15.0:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
 
   axobject-query@4.1.0: {}
 
@@ -2667,6 +2810,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
@@ -2721,11 +2868,17 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  delayed-stream@1.0.0: {}
+
   detect-libc@2.1.2: {}
 
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dompurify@3.2.7:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3095,9 +3248,19 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  follow-redirects@1.16.0: {}
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
 
   function-bind@1.1.2: {}
 
@@ -3442,9 +3605,15 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lucide-react@1.8.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  marked@14.0.0: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -3455,6 +3624,12 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -3464,6 +3639,11 @@ snapshots:
       brace-expansion: 1.1.13
 
   minimist@1.2.8: {}
+
+  monaco-editor@0.55.1:
+    dependencies:
+      dompurify: 3.2.7
+      marked: 14.0.0
 
   ms@2.1.3: {}
 
@@ -3608,6 +3788,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
 
@@ -3777,6 +3959,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   stable-hash@0.0.5: {}
+
+  state-local@1.0.7: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:


### PR DESCRIPTION
hooked up the real api instead of just logging to console. now it actually builds the payload, sends it off, and shuffles you over to the results page if everything's good.

- hook up the real api instead of just logging to console
- map form data to the correct payload format for both workflows
- add loading and error states so the user knows what's happening
- store generation output in session storage and redirect to /result
- polish the UI with better spacing and updated icons
- remove .codex and CLAUDE.md files