### PR TITLE
refactor(app): fix mobile layouts and beef up result page state

### DIFF
--- a/app/generate/page.tsx
+++ b/app/generate/page.tsx
@@ -160,7 +160,7 @@ export default function GeneratePage() {
 
   return (
     <div className="relative flex min-h-screen flex-col items-center bg-[#09090b] px-6 py-12 font-sans text-zinc-50 selection:bg-zinc-800">
-      <div className="absolute top-6 left-6 md:top-8 md:left-8 z-20">
+      <div className="relative md:absolute top-0 left-0 md:top-8 md:left-8 z-20 w-full md:w-auto mb-6 md:mb-0">
         <Link
           href="/"
           className="inline-flex items-center gap-2 text-sm text-zinc-500 transition-colors hover:text-white"
@@ -170,7 +170,7 @@ export default function GeneratePage() {
         </Link>
       </div>
 
-      <div className="relative z-10 mt-4 w-full max-w-3xl space-y-8 md:mt-8">
+      <div className="relative z-10 w-full max-w-3xl space-y-8">
         <div className="text-center space-y-3 pb-4">
           <h1 className="text-3xl font-medium tracking-tight text-white">
             Generate your package

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,10 +23,10 @@ export default function Home() {
           Turn your Go binaries into installable npm packages with the release wiring already handled.
         </p>
 
-        <div className="mt-12 flex flex-col items-start gap-5 sm:flex-row sm:items-center">
+        <div className="mt-12 flex w-full flex-col items-stretch gap-4 sm:flex-row sm:items-center sm:justify-start">
           <Link
             href="/generate"
-            className="group flex h-12 items-center justify-center gap-2.5 rounded-full bg-white px-8 text-sm font-semibold text-black shadow-[0_0_40px_-15px_rgba(255,255,255,0.5)] transition-all hover:scale-[1.02] hover:bg-zinc-200 active:scale-95 sm:h-14"
+            className="group flex h-12 w-full sm:w-auto items-center justify-center gap-2.5 rounded-full bg-white px-8 text-sm font-semibold text-black shadow-[0_0_40px_-15px_rgba(255,255,255,0.5)] transition-all hover:scale-[1.02] hover:bg-zinc-200 active:scale-95 sm:h-14"
           >
             Start Generating
             <svg
@@ -41,7 +41,7 @@ export default function Home() {
           </Link>
           <Link
             href="#"
-            className="flex h-12 sm:h-14 items-center justify-center rounded-full border border-white/10 bg-white/5 px-8 text-sm font-medium text-zinc-300 transition-all hover:bg-white/10 hover:text-white active:scale-95"
+            className="flex h-12 w-full sm:w-auto sm:h-14 items-center justify-center rounded-full border border-white/10 bg-white/5 px-8 text-sm font-medium text-zinc-300 transition-all hover:bg-white/10 hover:text-white active:scale-95"
           >
             Learn More
           </Link>

--- a/app/result/page.tsx
+++ b/app/result/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
-import { Editor } from "@monaco-editor/react";
+import React, { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { Editor, type OnMount } from "@monaco-editor/react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -13,6 +13,8 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { ArrowLeft, Copy, FileCode2, Check, DownloadCloud, Code2, Pencil, Lock } from "lucide-react";
 import Link from "next/link";
+import JSZip from "jszip";
+import { saveAs } from "file-saver";
 
 interface SessionData {
   workflow: "go-release" | "npm-wrapper";
@@ -22,10 +24,57 @@ interface SessionData {
     version?: string;
     platforms: string[];
     asset_urls?: Record<string, string>;
-    [key: string]: any;
+    [key: string]: unknown;
   };
   files: Record<string, string>;
 }
+
+const GENERATED_RESULT_KEY = "generated-result";
+let cachedGeneratedResultRaw: string | null = null;
+let cachedGeneratedResultParsed: SessionData | null = null;
+
+const subscribeToGeneratedResult = (callback: () => void) => {
+  if (typeof window === "undefined") {
+    return () => undefined;
+  }
+
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === GENERATED_RESULT_KEY) {
+      callback();
+    }
+  };
+
+  window.addEventListener("storage", handleStorage);
+  return () => window.removeEventListener("storage", handleStorage);
+};
+
+const readGeneratedResult = (): SessionData | null => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const raw = sessionStorage.getItem(GENERATED_RESULT_KEY);
+  if (!raw) {
+    cachedGeneratedResultRaw = null;
+    cachedGeneratedResultParsed = null;
+    return null;
+  }
+
+  if (raw === cachedGeneratedResultRaw) {
+    return cachedGeneratedResultParsed;
+  }
+
+  try {
+    cachedGeneratedResultRaw = raw;
+    cachedGeneratedResultParsed = JSON.parse(raw) as SessionData;
+    return cachedGeneratedResultParsed;
+  } catch (err) {
+    console.error("Failed to parse session data", err);
+    cachedGeneratedResultRaw = null;
+    cachedGeneratedResultParsed = null;
+    return null;
+  }
+};
 
 const getLanguage = (filename: string) => {
   const ext = filename.split(".").pop()?.toLowerCase();
@@ -46,51 +95,78 @@ const getLanguage = (filename: string) => {
 };
 
 export default function ResultPage() {
-  const [resultData, setResultData] = useState<SessionData | null>(null);
-  const [isLoaded, setIsLoaded] = useState(false);
+  const resultData = useSyncExternalStore(
+    subscribeToGeneratedResult,
+    readGeneratedResult,
+    () => null
+  );
   const [activeFile, setActiveFile] = useState<string>("");
-  const [fileContents, setFileContents] = useState<Record<string, string>>({});
+  const [editedContents, setEditedContents] = useState<Record<string, string>>({});
   const [copied, setCopied] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
+  const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
+  const fileContents = {
+    ...(resultData?.files ?? {}),
+    ...editedContents,
+  };
+  const defaultFile = Object.keys(resultData?.files ?? {})[0] ?? "";
+  const selectedFile = activeFile && fileContents[activeFile] !== undefined ? activeFile : defaultFile;
 
   useEffect(() => {
-    const raw = sessionStorage.getItem("generated-result");
-    if (raw) {
-      try {
-        const parsed = JSON.parse(raw) as SessionData;
-        setResultData(parsed);
-        setFileContents(parsed.files);
-        const keys = Object.keys(parsed.files);
-        if (keys.length > 0) {
-          setActiveFile(keys[0]);
-        }
-      } catch (err) {
-        console.error("Failed to parse session data", err);
-      }
-    }
-    setIsLoaded(true);
-  }, []);
+    if (!editorRef.current || !selectedFile) return;
+
+    const layoutEditor = () => editorRef.current?.layout();
+    const frame = requestAnimationFrame(layoutEditor);
+
+    window.addEventListener("resize", layoutEditor);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener("resize", layoutEditor);
+    };
+  }, [isEditing, selectedFile]);
 
   const handleEditorChange = (value: string | undefined) => {
-    if (value !== undefined) {
-      setFileContents((prev) => ({ ...prev, [activeFile]: value }));
+    if (value !== undefined && selectedFile) {
+      setEditedContents((prev) => ({ ...prev, [selectedFile]: value }));
     }
   };
 
   const handleCopy = () => {
-    if (!fileContents[activeFile]) return;
-    navigator.clipboard.writeText(fileContents[activeFile]);
+    if (!selectedFile || !fileContents[selectedFile]) return;
+    navigator.clipboard.writeText(fileContents[selectedFile]);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
 
-  if (!isLoaded) {
-    return (
-      <div className="min-h-screen bg-[#09090b] text-zinc-50 flex items-center justify-center font-sans">
-        <div className="text-zinc-500 text-sm">Loading workspace...</div>
-      </div>
-    );
-  }
+  const handleDownloadZip = async () => {
+  
+    const zip = new JSZip();
+    
+    
+    
+    Object.entries(fileContents).forEach(([filename, content]) => {
+      zip.file(filename, content);
+    });
+
+  
+    const binaryName = resultData?.summary?.binary_name || "generated-package";
+    
+    try {
+   
+      const blob = await zip.generateAsync({ type: "blob" });
+      
+    
+      saveAs(blob, `${binaryName}.zip`);
+    } catch (err) {
+      console.error("Failed to generate ZIP", err);
+    }
+  };
+
+  const handleEditorMount: OnMount = (editor) => {
+    editorRef.current = editor;
+    editor.layout();
+  };
 
   if (!resultData) {
     return (
@@ -106,11 +182,11 @@ export default function ResultPage() {
   const isNpmWrapper = resultData.workflow === "npm-wrapper";
 
   return (
-    <div className="min-h-screen bg-[#09090b] text-zinc-50 font-sans selection:bg-zinc-800">
+    <div className="min-h-screen flex flex-col bg-[#09090b] text-zinc-50 font-sans selection:bg-zinc-800">
 
-      <div className="w-full px-6 lg:px-10 py-6 lg:py-8 space-y-8">
+      <div className="w-full px-6 lg:px-10 py-6 flex flex-col flex-1 min-h-0 gap-6">
         {/* Header Section */}
-        <div className="flex flex-col md:flex-row md:items-end justify-between gap-6">
+        <div className="flex flex-col md:flex-row md:items-end justify-between gap-6 shrink-0">
           <div className="space-y-2">
             <h1 className="text-3xl font-medium tracking-tight text-white">Generated Output</h1>
             <p className="text-zinc-400 text-sm">Review, edit, and copy your generated files</p>
@@ -122,29 +198,29 @@ export default function ResultPage() {
         </div>
 
         {/* Action Buttons */}
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col sm:flex-row items-stretch sm:items-center justify-between gap-4 shrink-0">
           <Link href="/generate" className="inline-flex">
             <Button variant="ghost" size="sm" className="gap-2 text-zinc-400 hover:text-white">
               <ArrowLeft className="w-4 h-4" />
               Back to edit
             </Button>
           </Link>
-          <Button variant="primary" size="sm" className="gap-2">
+          <Button variant="primary" size="sm" className="gap-2 w-full sm:w-auto" onClick={handleDownloadZip}>
             <DownloadCloud className="w-4 h-4" />
             Download ZIP
           </Button>
         </div>
 
         {/* Main 2-Column Grid */}
-        <div className="grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-6 items-start">
+        <div className="flex flex-col lg:flex-row gap-6 flex-1 min-h-[800px] lg:min-h-[85vh] pb-6 lg:pb-8">
 
           {/* Left Panel - Input Summary */}
-          <Card className="sticky top-6">
-            <CardHeader>
+          <Card className="flex flex-col lg:w-[320px] shrink-0 min-h-0 lg:h-full lg:max-h-full">
+            <CardHeader className="shrink-0">
               <CardTitle>Input Summary</CardTitle>
               <CardDescription>Values used for generation</CardDescription>
             </CardHeader>
-            <CardContent className="space-y-6">
+            <CardContent className="space-y-6 overflow-y-auto min-h-0 flex-1">
               <div className="space-y-1">
                 <p className="text-xs font-medium text-zinc-500 uppercase tracking-wider">Repository URL</p>
                 <p className="text-sm font-mono text-zinc-300 truncate" title={resultData.summary.repo_url}>
@@ -204,14 +280,14 @@ export default function ResultPage() {
           </Card>
 
           {/* Right Panel - Workspace */}
-          <div className="flex flex-col lg:flex-row h-[75vh] min-h-[500px] rounded-xl border border-white/[0.08] bg-[#0c0c0e] overflow-hidden shadow-2xl">
+          <div className="flex-1 flex flex-col lg:flex-row min-h-[600px] lg:min-h-[85vh] min-w-0 rounded-xl border border-white/[0.08] bg-[#0c0c0e] overflow-hidden shadow-2xl">
 
             {/* File Explorer Sidebar */}
-            <div className="w-full lg:w-64 border-r border-white/[0.08] flex flex-col bg-[#09090b]">
-              <div className="px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wider border-b border-white/[0.08] flex items-center justify-between">
+            <div className="w-full h-[30%] lg:h-auto lg:w-64 shrink-0 lg:shrink border-b lg:border-b-0 lg:border-r border-white/[0.08] flex flex-col bg-[#09090b] min-h-0">
+              <div className="px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wider border-b border-white/[0.08] flex items-center justify-between shrink-0">
                 <span>Explorer</span>
               </div>
-              <div className="flex-1 overflow-y-auto py-2">
+              <div className="flex-1 overflow-y-auto py-2 min-h-0">
                 <div className="px-2 pb-1">
                   <div className="px-2 py-1 text-xs font-medium text-zinc-400 flex items-center gap-1.5 opacity-80">
                     <ChevronDownIcon className="w-3.5 h-3.5" />
@@ -222,12 +298,12 @@ export default function ResultPage() {
                       <button
                         key={filename}
                         onClick={() => setActiveFile(filename)}
-                        className={`w-full flex items-center gap-2 px-6 py-1.5 text-sm transition-colors ${activeFile === filename
+                        className={`w-full flex items-center gap-2 px-6 py-1.5 text-sm transition-colors ${selectedFile === filename
                           ? "bg-white/[0.08] text-white"
                           : "text-zinc-400 hover:bg-white/[0.04] hover:text-zinc-200"
                           }`}
                       >
-                        <FileCode2 className={`w-4 h-4 ${activeFile === filename ? "text-emerald-400" : "text-zinc-500"}`} />
+                        <FileCode2 className={`w-4 h-4 ${selectedFile === filename ? "text-emerald-400" : "text-zinc-500"}`} />
                         <span className="truncate">{filename}</span>
                       </button>
                     ))}
@@ -237,19 +313,25 @@ export default function ResultPage() {
             </div>
 
             {/* Editor Content Area */}
-            <div className="flex-1 flex flex-col min-w-0 bg-[#0c0c0e] relative">
-              <div className="flex items-center justify-between px-4 py-2 border-b border-white/[0.08] bg-[#09090b]">
+            <div className="flex-1 flex flex-col min-w-0 min-h-0 bg-[#0c0c0e]">
+              <div className="shrink-0 flex flex-col gap-3 px-4 py-3 border-b border-white/[0.08] bg-[#09090b] sm:flex-row sm:items-center sm:justify-between">
                 <div className="flex items-center gap-2 text-sm text-zinc-300 px-3 py-1.5 bg-white/[0.04] rounded-md border border-white/[0.04]">
                   <FileCode2 className="w-4 h-4 text-emerald-400" />
-                  {activeFile || "Select a file"}
+                  {selectedFile || "Select a file"}
                 </div>
-                <div className="flex items-center gap-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  {!isEditing && selectedFile ? (
+                    <div className="inline-flex items-center gap-2 rounded-full border border-amber-400/30 bg-amber-400/10 px-3 py-1 text-xs font-medium text-amber-200">
+                      <span className="h-2 w-2 rounded-full bg-amber-300 animate-pulse" />
+                      Click Edit to modify this file
+                    </div>
+                  ) : null}
                   <Button
                     variant="ghost"
                     size="sm"
                     className="h-8 gap-2 text-zinc-400 hover:text-white"
                     onClick={handleCopy}
-                    disabled={!activeFile}
+                    disabled={!selectedFile}
                   >
                     {copied ? <Check className="w-3.5 h-3.5 text-emerald-400" /> : <Copy className="w-3.5 h-3.5" />}
                     {copied ? "Copied" : "Copy"}
@@ -257,13 +339,12 @@ export default function ResultPage() {
                   <Button
                     variant="ghost"
                     size="sm"
-                    className={`h-8 gap-2 transition-colors ${
-                      isEditing
-                        ? "text-emerald-400 hover:text-emerald-300"
-                        : "text-zinc-400 hover:text-white"
-                    }`}
+                    className={`h-8 gap-2 border transition-all ${isEditing
+                        ? "border-emerald-400/40 bg-emerald-400/10 text-emerald-300 hover:bg-emerald-400/15 hover:text-emerald-200"
+                        : "border-amber-400/40 bg-amber-400/10 text-amber-200 shadow-[0_0_0_1px_rgba(251,191,36,0.08)] hover:border-amber-300/60 hover:bg-amber-400/15 hover:text-amber-100"
+                      }`}
                     onClick={() => setIsEditing((prev) => !prev)}
-                    disabled={!activeFile}
+                    disabled={!selectedFile}
                   >
                     {isEditing ? <Pencil className="w-3.5 h-3.5" /> : <Lock className="w-3.5 h-3.5" />}
                     {isEditing ? "Editing" : "Edit"}
@@ -271,32 +352,35 @@ export default function ResultPage() {
                 </div>
               </div>
 
-              <div className="flex-1 w-full relative">
-                {activeFile ? (
-                  <Editor
-                    height="100%"
-                    language={getLanguage(activeFile)}
-                    theme="vs-dark"
-                    value={fileContents[activeFile] || ""}
-                    onChange={isEditing ? handleEditorChange : undefined}
-                    options={{
-                      minimap: { enabled: false },
-                      fontSize: 14,
-                      lineHeight: 1.6,
-                      padding: { top: 24, bottom: 24 },
-                      scrollBeyondLastLine: false,
-                      smoothScrolling: true,
-                      cursorBlinking: "smooth",
-                      readOnly: !isEditing,
-                      fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', Consolas, monospace",
-                    }}
-                    className="absolute inset-0"
-                    loading={
-                      <div className="flex items-center justify-center h-full text-zinc-500 text-sm">
-                        Loading editor...
-                      </div>
-                    }
-                  />
+              <div className="flex-1 min-h-0 min-w-0 bg-[#111317]">
+                {selectedFile ? (
+                  <div className="h-full w-full overflow-hidden">
+                    <Editor
+                      height="100%"
+                      language={getLanguage(selectedFile)}
+                      theme="vs-dark"
+                      value={fileContents[selectedFile] || ""}
+                      onMount={handleEditorMount}
+                      onChange={isEditing ? handleEditorChange : undefined}
+                      options={{
+                        automaticLayout: true,
+                        minimap: { enabled: false },
+                        fontSize: 14,
+                        lineHeight: 24,
+                        padding: { top: 24, bottom: 24 },
+                        scrollBeyondLastLine: false,
+                        smoothScrolling: true,
+                        cursorBlinking: "smooth",
+                        readOnly: !isEditing,
+                        fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', Consolas, monospace",
+                      }}
+                      loading={
+                        <div className="flex items-center justify-center h-full text-zinc-500 text-sm">
+                          Loading editor...
+                        </div>
+                      }
+                    />
+                  </div>
                 ) : (
                   <div className="flex items-center justify-center h-full text-zinc-500 text-sm">
                     No file selected

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
     "axios": "^1.15.0",
+    "file-saver": "^2.0.5",
+    "jszip": "^3.10.1",
     "lucide-react": "^1.8.0",
     "monaco-editor": "^0.55.1",
     "next": "16.2.3",
@@ -19,6 +21,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/file-saver": "^2.0.7",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       axios:
         specifier: ^1.15.0
         version: 1.15.0
+      file-saver:
+        specifier: ^2.0.5
+        version: 2.0.5
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       lucide-react:
         specifier: ^1.8.0
         version: 1.8.0(react@19.2.4)
@@ -33,6 +39,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.2
+      '@types/file-saver':
+        specifier: ^2.0.7
+        version: 2.0.7
       '@types/node':
         specifier: ^20
         version: 20.19.39
@@ -551,6 +560,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/file-saver@2.0.7':
+    resolution: {integrity: sha512-dNKVfHd/jk0SkR/exKGj2ggkB45MAkzvWCaqLUUgkyjITkGNzH8H+yUwr+BLJUBjZOe9w8X3wgmXhZDRg1ED6A==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -885,6 +897,9 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1153,6 +1168,9 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  file-saver@2.0.5:
+    resolution: {integrity: sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -1286,6 +1304,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -1293,6 +1314,9 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -1401,6 +1425,9 @@ packages:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -1449,6 +1476,9 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -1462,6 +1492,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1689,6 +1722,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -1731,6 +1767,9 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -1756,6 +1795,9 @@ packages:
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -1788,6 +1830,9 @@ packages:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -1819,6 +1864,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -1884,6 +1932,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -1991,6 +2042,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -2470,6 +2524,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/file-saver@2.0.7': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -2817,6 +2873,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
+
+  core-util-is@1.0.3: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3232,6 +3290,8 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  file-saver@2.0.5: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -3360,12 +3420,16 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immediate@3.0.6: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -3485,6 +3549,8 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
+  isarray@1.0.0: {}
+
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
@@ -3527,6 +3593,13 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -3541,6 +3614,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -3751,6 +3828,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -3783,6 +3862,8 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  process-nextick-args@2.0.1: {}
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -3803,6 +3884,16 @@ snapshots:
   react-is@16.13.1: {}
 
   react@19.2.4: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -3851,6 +3942,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.1.2: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -3889,6 +3982,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setimmediate@1.0.5: {}
 
   sharp@0.34.5:
     dependencies:
@@ -4016,6 +4111,10 @@ snapshots:
       call-bind: 1.0.9
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   strip-bom@3.0.0: {}
 
@@ -4152,6 +4251,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  util-deprecate@1.0.2: {}
 
   which-boxed-primitive@1.1.1:
     dependencies:


### PR DESCRIPTION
- use useSyncExternalStore so session data doesn't get wonky
- make buttons full-width on mobile and fix some positioning in /generate
- add jszip and file-saver so we can actually download stuff later
- let users edit files directly in the code editor
- fix editor layout bugs when the window changes size or editing state flips
- organize session data access with a cleaner caching layer