### PR TITLE
style(generate): revamp the generator layout and ui

### DIFF
--- a/app/generate/page.tsx
+++ b/app/generate/page.tsx
@@ -159,138 +159,134 @@ export default function GeneratePage() {
   };
 
   return (
-    <div className="relative flex min-h-screen flex-col items-center bg-[#09090b] px-6 py-12 font-sans text-zinc-50 selection:bg-zinc-800">
-      <div className="relative md:absolute top-0 left-0 md:top-8 md:left-8 z-20 w-full md:w-auto mb-6 md:mb-0">
-        <Link
-          href="/"
-          className="inline-flex items-center gap-2 text-sm text-zinc-500 transition-colors hover:text-white"
-        >
-          <ArrowLeft className="w-4 h-4" />
-          Back to home
-        </Link>
-      </div>
-
-      <div className="relative z-10 w-full max-w-3xl space-y-8">
-        <div className="text-center space-y-3 pb-4">
-          <h1 className="text-3xl font-medium tracking-tight text-white">
-            Generate your package
-          </h1>
-          <p className="mx-auto max-w-xl text-sm text-zinc-400">
-            Choose your workflow and fill in the required details to generate
-            the wrapper zip.
-          </p>
+    <div className="relative flex min-h-screen flex-col bg-black px-6 py-12 font-sans text-zinc-50 selection:bg-zinc-800">
+      <div className="w-full max-w-6xl mx-auto">
+        <div className="relative md:absolute top-0 left-0 md:top-8 md:left-8 z-20 w-full md:w-auto mb-10 md:mb-0">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 text-sm text-zinc-500 transition-colors hover:text-white"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back to home
+          </Link>
         </div>
 
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-          {FORM_OPTIONS.map((option) => {
-            const isActive = activeForm === option.id;
-            return (
-              <button
-                key={option.id}
-                type="button"
-                disabled={isGenerating}
-                onClick={() => {
-                  setActiveForm(option.id);
-                  setError(null);
-                }}
-                className={cn(
-                  "group relative flex cursor-pointer flex-col items-start rounded-xl border px-6 py-5 text-left transition-all disabled:cursor-not-allowed disabled:opacity-60",
-                  isActive
-                    ? "border-white/20 bg-white/[0.06] shadow-sm"
-                    : "border-white/[0.08] bg-white/[0.02] hover:border-white/15 hover:bg-white/[0.04]"
-                )}
-              >
-                <div className="mb-3 flex items-center gap-2.5">
-                  <div
+        <div className="mt-8 md:mt-24 grid md:grid-cols-[350px_1fr] gap-12">
+          {/* Left Column: Workflow Selection */}
+          <div className="md:sticky md:top-12 space-y-6 self-start">
+            <h2 className="text-xl font-medium tracking-tight text-white mb-2">
+              Choose your workflow
+            </h2>
+            <div className="grid grid-cols-1 gap-4">
+              {FORM_OPTIONS.map((option) => {
+                const isActive = activeForm === option.id;
+                return (
+                  <button
+                    key={option.id}
+                    type="button"
+                    disabled={isGenerating}
+                    onClick={() => {
+                      setActiveForm(option.id);
+                      setError(null);
+                    }}
                     className={cn(
-                      "h-2 w-2 rounded-full transition-all",
+                      "group relative flex cursor-pointer flex-col items-start rounded-xl border p-5 text-left transition-all disabled:cursor-not-allowed disabled:opacity-60",
                       isActive
-                        ? "bg-emerald-500"
-                        : "bg-zinc-600 group-hover:bg-zinc-500"
-                    )}
-                  />
-                  <span
-                    className={cn(
-                      "text-sm font-medium tracking-tight transition-colors",
-                      isActive
-                        ? "text-white"
-                        : "text-zinc-400 group-hover:text-zinc-300"
+                        ? "border-zinc-400 bg-zinc-900/40"
+                        : "border-zinc-800 bg-transparent hover:border-zinc-700"
                     )}
                   >
-                    {option.label}
-                  </span>
-                </div>
-                <p
-                  className={cn(
-                    "text-xs leading-relaxed transition-colors",
-                    isActive
-                      ? "text-zinc-400"
-                      : "text-zinc-500 group-hover:text-zinc-400"
-                  )}
-                >
-                  {option.description}
-                </p>
-              </button>
-            );
-          })}
-        </div>
-
-        <Card className={cn(isGenerating && "opacity-60 pointer-events-none")}>
-          <CardHeader>
-            <CardTitle>
-              {activeForm === "go-release"
-                ? "Go Release Configuration"
-                : "NPM Wrapper Configuration"}
-            </CardTitle>
-            <CardDescription>
-              {activeForm === "go-release"
-                ? "Configure your Go binary packaging details."
-                : "Specify registry setup for the npm wrapper package."}
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            {/* Active Form */}
-            {activeForm === "go-release" ? (
-              <GoReleaseForm data={goData} onChange={setGoData} />
-            ) : (
-              <NpmWrapperForm data={npmData} onChange={setNpmData} />
-            )}
-          </CardContent>
-        </Card>
-
-        {error && (
-          <div className="rounded-md bg-red-500/10 px-4 py-3 border border-red-500/20 text-sm text-red-400">
-            {error}
+                    <div className="mb-2 flex items-center gap-3">
+                      <div
+                        className={cn(
+                          "h-2 w-2 rounded-full transition-all flex-shrink-0",
+                          isActive ? "bg-emerald-500" : "bg-zinc-700 group-hover:bg-zinc-600"
+                        )}
+                      />
+                      <span
+                        className={cn(
+                          "text-base font-medium transition-colors",
+                          isActive ? "text-white" : "text-zinc-500 group-hover:text-zinc-300"
+                        )}
+                      >
+                        {option.label}
+                      </span>
+                    </div>
+                    <p
+                      className={cn(
+                        "text-sm leading-relaxed transition-colors mt-1 pl-5",
+                        isActive ? "text-zinc-400" : "text-zinc-600 group-hover:text-zinc-500"
+                      )}
+                    >
+                      {option.description}
+                    </p>
+                  </button>
+                );
+              })}
+            </div>
           </div>
-        )}
 
-        <div className="flex flex-col-reverse items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end pt-4">
-          <Button
-            variant="secondary"
-            size="sm"
-            className="w-full gap-2 sm:w-auto"
-            onClick={handleReset}
-            disabled={isGenerating}
-          >
-            <RefreshCcw className="w-3.5 h-3.5 text-zinc-400" />
-            Reset
-          </Button>
-          <Button
-            variant="primary"
-            size="sm"
-            className="w-full gap-2 sm:w-auto"
-            onClick={handleGenerate}
-            disabled={isGenerating}
-          >
-            {isGenerating ? (
-              <>Generating...</>
-            ) : (
-              <>
-                <PackagePlus className="w-4 h-4" />
-                Generate ZIP
-              </>
-            )}
-          </Button>
+          {/* Right Column: Configuration & Actions */}
+          <div className="space-y-8 md:pt-2">
+            <div className="space-y-1 mb-8">
+              <h2 className="text-2xl font-medium tracking-tight text-white">
+                Configuration
+              </h2>
+              <p className="text-sm text-zinc-400">
+                {activeForm === "go-release"
+                  ? "Configure your Go binary packaging details."
+                  : "Specify registry setup for the npm wrapper package."}
+              </p>
+            </div>
+
+            <div className={cn(isGenerating && "opacity-60 pointer-events-none", "space-y-8")}>
+              {/* Active Form */}
+              {activeForm === "go-release" ? (
+                <GoReleaseForm data={goData} onChange={setGoData} />
+              ) : (
+                <NpmWrapperForm data={npmData} onChange={setNpmData} />
+              )}
+
+              {error && (
+                <div className="rounded-md bg-red-500/10 px-4 py-3 border border-red-500/20 text-sm text-red-400">
+                  {error}
+                </div>
+              )}
+
+              <div className="flex flex-col-reverse items-stretch gap-4 sm:flex-row sm:items-center sm:justify-end pt-8 border-t border-zinc-800/50">
+                <Button
+                  variant="ghost"
+                  className="w-full gap-2 sm:w-auto text-zinc-400 hover:text-white bg-transparent hover:bg-zinc-900 sm:min-w-32"
+                  onClick={handleReset}
+                  disabled={isGenerating}
+                >
+                  <RefreshCcw className="w-4 h-4" />
+                  Reset
+                </Button>
+                <Button
+                  className={cn(
+                    "w-full gap-2 sm:w-auto sm:min-w-32 font-bold uppercase tracking-wider text-xs",
+                    "bg-white text-black border-2 border-white",
+                    "shadow-[4px_4px_0_0_#52525b]",
+                    "hover:bg-zinc-100 hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-[2px_2px_0_0_#52525b]",
+                    "active:translate-x-[4px] active:translate-y-[4px] active:shadow-none",
+                    "transition-all rounded-none"
+                  )}
+                  onClick={handleGenerate}
+                  disabled={isGenerating}
+                >
+                  {isGenerating ? (
+                    <>Generating...</>
+                  ) : (
+                    <>
+                      <PackagePlus className="w-4 h-4" />
+                      Generate ZIP
+                    </>
+                  )}
+                </Button>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/app/result/page.tsx
+++ b/app/result/page.tsx
@@ -113,6 +113,20 @@ export default function ResultPage() {
   const selectedFile = activeFile && fileContents[activeFile] !== undefined ? activeFile : defaultFile;
 
   useEffect(() => {
+    // Workaround for Monaco Editor crash in Firefox: "can't access property 'offsetNode', hitResult is null"
+    if (typeof window !== "undefined" && typeof document.caretPositionFromPoint === "function") {
+      const originalCaretPositionFromPoint = document.caretPositionFromPoint.bind(document);
+      document.caretPositionFromPoint = (x: number, y: number) => {
+        const result = originalCaretPositionFromPoint(x, y);
+        if (result === null) {
+          return { offsetNode: document.body, offset: 0 } as any;
+        }
+        return result;
+      };
+    }
+  }, []);
+
+  useEffect(() => {
     if (!editorRef.current || !selectedFile) return;
 
     const layoutEditor = () => editorRef.current?.layout();
@@ -248,11 +262,26 @@ export default function ResultPage() {
               <div className="space-y-2">
                 <p className="text-xs font-medium text-zinc-500 uppercase tracking-wider">Target Platforms ({resultData.summary.platforms?.length || 0})</p>
                 <div className="flex flex-wrap gap-2">
-                  {resultData.summary.platforms?.map((platform) => (
-                    <span key={platform} className="text-xs font-mono rounded bg-white/[0.04] border border-white/[0.08] px-2 py-1 text-zinc-300">
-                      {platform}
-                    </span>
-                  ))}
+                  {resultData.summary.platforms?.map((platform) => {
+                    let iconUrl = "";
+                    const p = platform.toLowerCase();
+                    if (p.includes("linux")) iconUrl = "https://files.svgcdn.io/flat-color-icons/linux.svg";
+                    else if (p.includes("darwin") || p.includes("mac")) iconUrl = "https://files.svgcdn.io/qlementine-icons/mac-16.svg";
+                    else if (p.includes("windows")) iconUrl = "https://files.svgcdn.io/devicon/windows8.svg";
+
+                    return (
+                      <span key={platform} className="inline-flex items-center gap-1.5 text-xs font-mono rounded bg-white/[0.04] border border-white/[0.08] px-2.5 py-1 text-zinc-300">
+                        {iconUrl && (
+                          <img 
+                            src={iconUrl} 
+                            alt={platform} 
+                            className={`w-3.5 h-3.5 ${p.includes("darwin") || p.includes("mac") ? "invert opacity-80" : ""}`} 
+                          />
+                        )}
+                        {platform}
+                      </span>
+                    );
+                  })}
                 </div>
               </div>
 

--- a/components/forms/go-release-form.tsx
+++ b/components/forms/go-release-form.tsx
@@ -2,9 +2,9 @@
 
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
 import { PLATFORM_OPTIONS, type PlatformId } from "@/lib/platforms";
+import { cn } from "@/lib/utils";
 
 export interface GoReleaseFormData {
   repoUrl: string;
@@ -49,30 +49,32 @@ export function GoReleaseForm({ data, onChange }: GoReleaseFormProps) {
     <div className="space-y-8">
       <div className="grid gap-6 sm:grid-cols-2">
         <div className="space-y-2.5">
-          <Label htmlFor="go-repo-url">Repository URL</Label>
+          <Label htmlFor="go-repo-url" className="text-zinc-400 text-sm">Repository URL</Label>
           <Input
             id="go-repo-url"
             placeholder="github.com/user/repo"
             value={data.repoUrl}
             onChange={(event) => update("repoUrl", event.target.value)}
+            className="py-3 px-4 h-auto bg-zinc-900/50 border-zinc-800 focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500 text-white rounded-lg transition-all"
           />
         </div>
         <div className="space-y-2.5">
-          <Label htmlFor="go-binary-name">Binary Name</Label>
+          <Label htmlFor="go-binary-name" className="text-zinc-400 text-sm">Binary Name</Label>
           <Input
             id="go-binary-name"
             placeholder="mytool"
             value={data.binaryName}
             onChange={(event) => updateBinaryName(event.target.value)}
+            className="py-3 px-4 h-auto bg-zinc-900/50 border-zinc-800 focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500 text-white rounded-lg transition-all"
           />
         </div>
       </div>
 
-      <Separator />
+      <Separator className="bg-zinc-800/50" />
 
       <div className="space-y-3">
-        <Label>Target Platforms</Label>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        <Label className="text-zinc-400 text-sm">Target Platforms</Label>
+        <div className="grid grid-cols-3 gap-4">
           {PLATFORM_OPTIONS.map((platform) => {
             const isChecked = data.platforms.includes(platform.id);
 
@@ -88,16 +90,17 @@ export function GoReleaseForm({ data, onChange }: GoReleaseFormProps) {
                     togglePlatform(platform.id, !isChecked);
                   }
                 }}
-                className="flex cursor-pointer items-center gap-3 rounded-lg border border-white/[0.08] bg-white/[0.02] px-3.5 py-3 transition-colors hover:border-white/20 hover:bg-white/[0.04]"
+                className={cn(
+                  "group flex cursor-pointer flex-col items-center justify-center rounded-xl border p-4 transition-all outline-none focus-visible:ring-2 focus-visible:ring-zinc-400",
+                  isChecked
+                    ? "border-zinc-400 bg-zinc-800/50"
+                    : "border-zinc-800 bg-transparent hover:border-zinc-700 hover:bg-zinc-900/30"
+                )}
               >
-                <Checkbox
-                  id={`go-platform-${platform.id}`}
-                  checked={isChecked}
-                  onCheckedChange={(checked) =>
-                    togglePlatform(platform.id, checked)
-                  }
-                />
-                <span className="text-sm text-zinc-300">{platform.label}</span>
+                {platform.id === "linux" && <img src="https://files.svgcdn.io/flat-color-icons/linux.svg" alt="Linux" className={cn("w-7 h-7 mb-3 transition-all", isChecked ? "opacity-100 drop-shadow-sm" : "opacity-50 grayscale group-hover:opacity-80 group-hover:grayscale-0")} />}
+                {platform.id === "darwin" && <img src="https://files.svgcdn.io/qlementine-icons/mac-16.svg" alt="macOS" className={cn("w-7 h-7 mb-3 transition-all", isChecked ? "opacity-100 drop-shadow-sm invert" : "opacity-50 grayscale invert group-hover:opacity-80")} />}
+                {platform.id === "windows" && <img src="https://files.svgcdn.io/devicon/windows8.svg" alt="Windows" className={cn("w-7 h-7 mb-3 transition-all", isChecked ? "opacity-100 drop-shadow-sm" : "opacity-50 grayscale group-hover:opacity-80 group-hover:grayscale-0")} />}
+                <span className={cn("text-xs font-medium transition-colors", isChecked ? "text-white" : "text-zinc-500 group-hover:text-zinc-300")}>{platform.label}</span>
               </div>
             );
           })}

--- a/components/forms/npm-wrapper-form.tsx
+++ b/components/forms/npm-wrapper-form.tsx
@@ -2,9 +2,9 @@
 
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
 import { PLATFORM_OPTIONS, type PlatformId } from "@/lib/platforms";
+import { cn } from "@/lib/utils";
 
 export interface NpmWrapperFormData {
   repoUrl: string;
@@ -77,40 +77,43 @@ export function NpmWrapperForm({ data, onChange }: NpmWrapperFormProps) {
     <div className="space-y-8">
       <div className="grid gap-6 sm:grid-cols-3">
         <div className="space-y-2.5">
-          <Label htmlFor="npm-repo-url">Repository URL</Label>
+          <Label htmlFor="npm-repo-url" className="text-zinc-400 text-sm">Repository URL</Label>
           <Input
             id="npm-repo-url"
             placeholder="github.com/user/repo"
             value={data.repoUrl}
             onChange={(event) => update("repoUrl", event.target.value)}
+            className="py-3 px-4 h-auto bg-zinc-900/50 border-zinc-800 focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500 text-white rounded-lg transition-all"
           />
         </div>
         <div className="space-y-2.5">
-          <Label htmlFor="npm-cli-command">Binary Name</Label>
+          <Label htmlFor="npm-cli-command" className="text-zinc-400 text-sm">Binary Name</Label>
           <Input
             id="npm-cli-command"
             placeholder="mytool"
             value={data.cliCommandName}
             onChange={(event) => updateCommandName(event.target.value)}
+            className="py-3 px-4 h-auto bg-zinc-900/50 border-zinc-800 focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500 text-white rounded-lg transition-all"
           />
         </div>
         <div className="space-y-2.5">
-          <Label htmlFor="npm-version">Version</Label>
+          <Label htmlFor="npm-version" className="text-zinc-400 text-sm">Version</Label>
           <Input
             id="npm-version"
             placeholder="1.0.0"
             value={data.version}
             onChange={(event) => update("version", event.target.value)}
+            className="py-3 px-4 h-auto bg-zinc-900/50 border-zinc-800 focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500 text-white rounded-lg transition-all"
           />
         </div>
       </div>
 
-      <Separator />
+      <Separator className="bg-zinc-800/50" />
 
       <div className="space-y-6">
         <div className="space-y-3">
-          <Label>Target Platforms</Label>
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          <Label className="text-zinc-400 text-sm">Target Platforms</Label>
+          <div className="grid grid-cols-3 gap-4">
             {PLATFORM_OPTIONS.map((platform) => {
               const isChecked = data.platforms.includes(platform.id);
 
@@ -126,20 +129,17 @@ export function NpmWrapperForm({ data, onChange }: NpmWrapperFormProps) {
                       togglePlatform(platform.id, !isChecked);
                     }
                   }}
-                  className={
+                  className={cn(
+                    "group flex cursor-pointer flex-col items-center justify-center rounded-xl border p-4 transition-all outline-none focus-visible:ring-2 focus-visible:ring-zinc-400",
                     isChecked
-                      ? "flex cursor-pointer items-center gap-3 rounded-lg border border-white/20 bg-white/[0.06] px-3.5 py-3 transition-colors"
-                      : "flex cursor-pointer items-center gap-3 rounded-lg border border-white/[0.08] bg-white/[0.02] px-3.5 py-3 transition-colors hover:border-white/20 hover:bg-white/[0.04]"
-                  }
+                      ? "border-zinc-400 bg-zinc-800/50"
+                      : "border-zinc-800 bg-transparent hover:border-zinc-700 hover:bg-zinc-900/30"
+                  )}
                 >
-                  <Checkbox
-                    id={`npm-platform-${platform.id}`}
-                    checked={isChecked}
-                    onCheckedChange={(checked) =>
-                      togglePlatform(platform.id, checked)
-                    }
-                  />
-                  <span className="text-sm text-zinc-300">{platform.label}</span>
+                  {platform.id === "linux" && <img src="https://files.svgcdn.io/flat-color-icons/linux.svg" alt="Linux" className={cn("w-7 h-7 mb-3 transition-all", isChecked ? "opacity-100 drop-shadow-sm" : "opacity-50 grayscale group-hover:opacity-80 group-hover:grayscale-0")} />}
+                  {platform.id === "darwin" && <img src="https://files.svgcdn.io/qlementine-icons/mac-16.svg" alt="macOS" className={cn("w-7 h-7 mb-3 transition-all", isChecked ? "opacity-100 drop-shadow-sm invert" : "opacity-50 grayscale invert group-hover:opacity-80")} />}
+                  {platform.id === "windows" && <img src="https://files.svgcdn.io/devicon/windows8.svg" alt="Windows" className={cn("w-7 h-7 mb-3 transition-all", isChecked ? "opacity-100 drop-shadow-sm" : "opacity-50 grayscale group-hover:opacity-80 group-hover:grayscale-0")} />}
+                  <span className={cn("text-xs font-medium transition-colors", isChecked ? "text-white" : "text-zinc-500 group-hover:text-zinc-300")}>{platform.label}</span>
                 </div>
               );
             })}
@@ -148,13 +148,13 @@ export function NpmWrapperForm({ data, onChange }: NpmWrapperFormProps) {
 
         {selectedPlatforms.length > 0 && (
           <div className="space-y-4 py-2">
-            <Label className="text-zinc-400">Platform Asset URLs</Label>
+            <Label className="text-zinc-400 text-sm">Platform Asset URLs</Label>
             <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
               {selectedPlatforms.map((platform) => (
                 <div key={platform.id} className="space-y-2.5">
                   <Label
                     htmlFor={`npm-asset-${platform.id}`}
-                    className="text-xs text-zinc-400"
+                    className="text-xs text-zinc-500"
                   >
                     {platform.label} URL
                   </Label>
@@ -165,6 +165,7 @@ export function NpmWrapperForm({ data, onChange }: NpmWrapperFormProps) {
                     onChange={(event) =>
                       updateAssetUrl(platform.id, event.target.value)
                     }
+                    className="py-3 px-4 h-auto bg-zinc-900/50 border-zinc-800 focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500 text-white rounded-lg transition-all"
                   />
                 </div>
               ))}


### PR DESCRIPTION
- switched to a two-column grid layout
- moved the workflow selection to a sticky sidebar on the left
- updated the buttons to have a more distinct, punchy style
- cleaned up the forms by ditching the card wrappers
- tweaked spacing and background colors to make it look tighter