### PR TITLE
feat(npm-wrapper): allow multiple assets and filter non-binaries

### DIFF
--- a/app/generate/page.tsx
+++ b/app/generate/page.tsx
@@ -24,22 +24,48 @@ function toUiPlatform(platform: string): string {
   return platform;
 }
 
-function toUiAssetUrls(assetUrls: Record<string, string> | undefined): Record<string, string> {
+function toUiAssetUrls(assetUrls: Record<string, string[]> | undefined): Record<string, string[]> {
   if (!assetUrls) {
     return {};
   }
 
-  return Object.entries(assetUrls).reduce<Record<string, string>>((accumulator, [platform, url]) => {
-    accumulator[toUiPlatform(platform)] = url;
-    return accumulator;
-  }, {});
+  const result: Record<string, string[]> = {};
+
+  Object.entries(assetUrls).forEach(([platform, urls]) => {
+    const uiOs = toUiPlatform(platform);
+
+    // Filter out non-binary files
+    const binaryUrls = (Array.isArray(urls) ? urls : [urls]).filter(url => {
+      if (typeof url !== "string" || !url.trim()) return false;
+      const lowerUrl = url.toLowerCase();
+      return !lowerUrl.endsWith('.txt') && 
+             !lowerUrl.endsWith('.sha256') && 
+             !lowerUrl.endsWith('.sha512') &&
+             !lowerUrl.endsWith('.sig') &&
+             !lowerUrl.includes('checksum');
+    });
+
+    if (binaryUrls.length > 0) {
+      if (!result[uiOs]) {
+        result[uiOs] = [];
+      }
+      result[uiOs].push(...binaryUrls);
+    }
+  });
+
+  return result;
 }
 
 function buildNpmData(repoUrl: string, prefill: PrefillResponse): NpmWrapperFormData {
   const binaryName = prefill.binary_name?.trim() ?? "";
-  const platforms = Array.isArray(prefill.platforms)
-    ? prefill.platforms.map((platform) => toUiPlatform(platform))
-    : [];
+  
+  const assetUrls = toUiAssetUrls(prefill.asset_urls);
+  let platforms = Object.keys(assetUrls);
+
+  // Fallback if no asset urls but platforms exist
+  if (platforms.length === 0 && Array.isArray(prefill.platforms)) {
+    platforms = prefill.platforms.map((platform) => toUiPlatform(platform));
+  }
 
   return {
     ...INITIAL_NPM_WRAPPER_DATA,
@@ -49,15 +75,15 @@ function buildNpmData(repoUrl: string, prefill: PrefillResponse): NpmWrapperForm
     license: prefill.license?.trim() || "MIT",
     description: prefill.description?.trim() ?? "",
     version: prefill.version?.trim() ?? "",
-    platforms,
-    assetUrls: toUiAssetUrls(prefill.asset_urls),
+    platforms: Array.from(new Set(platforms)),
+    assetUrls,
   };
 }
 
 function buildGoData(repoUrl: string, prefill: PrefillResponse): GoReleaseFormData {
   const binaryName = prefill.binary_name?.trim() ?? "";
   const platforms = Array.isArray(prefill.platforms)
-    ? prefill.platforms.map((platform) => toUiPlatform(platform))
+    ? prefill.platforms.map((platform) => `${toUiPlatform(platform)}-amd64`)
     : [];
 
   return {
@@ -66,7 +92,7 @@ function buildGoData(repoUrl: string, prefill: PrefillResponse): GoReleaseFormDa
     binaryName,
     packageName: prefill.package_name?.trim() || binaryName,
     description: prefill.description?.trim() ?? "",
-    platforms,
+    platforms: Array.from(new Set(platforms)),
   };
 }
 

--- a/app/result/page.tsx
+++ b/app/result/page.tsx
@@ -176,6 +176,15 @@ function ResultPageContent() {
       };
 
       if (activeDistributor === "npm_wrapper") {
+        // Map form platform IDs (linux/darwin/windows) to API format (linux-amd64/darwin-arm64/windows-amd64)
+        const assetUrls: Record<string, string[]> = {};
+        for (const platform of npmWrapperData.platforms) {
+          const urls = (npmWrapperData.assetUrls[platform] || []).filter(u => u.trim() !== "");
+          if (urls.length > 0) {
+            assetUrls[mapPlatform(platform)] = urls;
+          }
+        }
+
         Object.assign(payload, {
           binary_name: npmWrapperData.cliCommandName,
           package_name: npmWrapperData.packageName,
@@ -184,12 +193,7 @@ function ResultPageContent() {
           version: npmWrapperData.version,
           platforms: mapPlatformsList(npmWrapperData.platforms),
           mode: "manual",
-          asset_urls: Object.fromEntries(
-            npmWrapperData.platforms.map((platform) => [
-              mapPlatform(platform),
-              npmWrapperData.assetUrls[platform] ?? "",
-            ])
-          ),
+          asset_urls: assetUrls,
         });
       }
 

--- a/components/forms/npm-wrapper-form.tsx
+++ b/components/forms/npm-wrapper-form.tsx
@@ -14,7 +14,7 @@ export interface NpmWrapperFormData {
   description: string;
   version: string;
   platforms: string[];
-  assetUrls: Record<string, string>;
+  assetUrls: Record<string, string[]>;
 }
 
 export const INITIAL_NPM_WRAPPER_DATA: NpmWrapperFormData = {
@@ -66,23 +66,38 @@ export function NpmWrapperForm({ data, onChange }: NpmWrapperFormProps) {
   const togglePlatform = (platformId: PlatformId, checked: boolean) => {
     const platforms = checked
       ? [...new Set([...safeData.platforms, platformId])]
-      : safeData.platforms.filter((platform) => platform !== platformId);
+      : safeData.platforms.filter((p) => p !== platformId);
 
     const assetUrls = { ...safeData.assetUrls };
 
     if (checked && !(platformId in assetUrls)) {
-      assetUrls[platformId] = "";
+      assetUrls[platformId] = [""];
     }
 
-    onChange({
-      ...safeData,
-      platforms,
-      assetUrls,
-    });
+    if (!checked) {
+      delete assetUrls[platformId];
+    }
+
+    onChange({ ...safeData, platforms, assetUrls });
   };
 
-  const updateAssetUrl = (platformId: PlatformId, url: string) => {
-    update("assetUrls", { ...safeData.assetUrls, [platformId]: url });
+  const updateAssetUrl = (platformId: string, index: number, url: string) => {
+    const currentUrls = [...(safeData.assetUrls[platformId] ?? [""])];
+    currentUrls[index] = url;
+    update("assetUrls", { ...safeData.assetUrls, [platformId]: currentUrls });
+  };
+
+  const addAssetUrl = (platformId: string) => {
+    const currentUrls = [...(safeData.assetUrls[platformId] ?? [])];
+    currentUrls.push("");
+    update("assetUrls", { ...safeData.assetUrls, [platformId]: currentUrls });
+  };
+
+  const removeAssetUrl = (platformId: string, index: number) => {
+    const currentUrls = [...(safeData.assetUrls[platformId] ?? [])];
+    currentUrls.splice(index, 1);
+    if (currentUrls.length === 0) currentUrls.push("");
+    update("assetUrls", { ...safeData.assetUrls, [platformId]: currentUrls });
   };
 
   const selectedPlatforms = PLATFORM_OPTIONS.filter((platform) =>
@@ -208,26 +223,54 @@ export function NpmWrapperForm({ data, onChange }: NpmWrapperFormProps) {
         {selectedPlatforms.length > 0 && (
           <div className="space-y-4 py-2">
             <Label className="text-zinc-400 text-sm">Platform Asset URLs</Label>
-            <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
-              {selectedPlatforms.map((platform) => (
-                <div key={platform.id} className="space-y-2.5">
-                  <Label
-                    htmlFor={`npm-asset-${platform.id}`}
-                    className="text-xs text-zinc-500"
-                  >
-                    {platform.label} URL
-                  </Label>
-                  <Input
-                    id={`npm-asset-${platform.id}`}
-                    placeholder={`https://.../${platform.id}-binary`}
-                    value={safeData.assetUrls[platform.id] ?? ""}
-                    onChange={(event) =>
-                      updateAssetUrl(platform.id, event.target.value)
-                    }
-                    className="py-3 px-4 h-auto bg-zinc-900/50 border-zinc-800 focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500 text-white rounded-none transition-all"
-                  />
-                </div>
-              ))}
+            <div className="space-y-5">
+              {selectedPlatforms.map((platform) => {
+                const urls = safeData.assetUrls[platform.id] ?? [""];
+
+                return (
+                  <div key={platform.id} className="space-y-2.5">
+                    <Label className="text-xs text-zinc-500 uppercase tracking-wide">
+                      {platform.label}
+                    </Label>
+                    <div className="space-y-2">
+                      {urls.map((url, index) => (
+                        <div key={index} className="flex items-center gap-2">
+                          <Input
+                            placeholder={`https://.../${platform.id}-binary`}
+                            value={url}
+                            onChange={(event) =>
+                              updateAssetUrl(platform.id, index, event.target.value)
+                            }
+                            className="py-2.5 px-4 h-auto bg-zinc-900/50 border-zinc-800 focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500 text-white rounded-none transition-all flex-1"
+                          />
+                          {urls.length > 1 && (
+                            <button
+                              type="button"
+                              onClick={() => removeAssetUrl(platform.id, index)}
+                              className="shrink-0 flex items-center justify-center w-8 h-8 border border-zinc-800 text-zinc-500 hover:text-red-400 hover:border-red-800 transition-colors"
+                              title="Remove URL"
+                            >
+                              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                              </svg>
+                            </button>
+                          )}
+                        </div>
+                      ))}
+                      <button
+                        type="button"
+                        onClick={() => addAssetUrl(platform.id)}
+                        className="flex items-center gap-1.5 text-xs text-zinc-500 hover:text-zinc-300 transition-colors mt-1"
+                      >
+                        <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+                        </svg>
+                        Add URL
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
             </div>
           </div>
         )}

--- a/lib/app-context.tsx
+++ b/lib/app-context.tsx
@@ -24,7 +24,7 @@ export interface PrefillResponse {
   description?: string;
   version?: string;
   platforms?: string[];
-  asset_urls?: Record<string, string>;
+  asset_urls?: Record<string, string[]>;
 }
 
 export interface AppContextType {

--- a/lib/generated-result.ts
+++ b/lib/generated-result.ts
@@ -5,7 +5,7 @@ export interface GeneratedSummary {
   binary_name: string;
   version?: string;
   platforms: string[];
-  asset_urls?: Record<string, string>;
+  asset_urls?: Record<string, string[]>;
   [key: string]: unknown;
 }
 

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -10,7 +10,10 @@ const NPM_PACKAGE_NAME_PATTERN = /^(?:@[^/\s]+\/)?[a-z0-9][a-z0-9._-]*$/;
 
 function isValidUrl(value: string) {
   try {
-    const url = new URL(value);
+    const urlString = value.startsWith("http://") || value.startsWith("https://") 
+      ? value 
+      : `https://${value}`;
+    const url = new URL(urlString);
     return url.protocol === "http:" || url.protocol === "https:";
   } catch {
     return false;
@@ -90,14 +93,20 @@ export function validateNpmWrapperForm(data: NpmWrapperFormData) {
   }
 
   for (const platform of data.platforms) {
-    const assetUrl = data.assetUrls[platform]?.trim();
+    const urls = data.assetUrls[platform];
 
-    if (!assetUrl) {
-      return `Add an asset URL for ${platform}.`;
+    if (!urls || urls.length === 0) {
+      return `Add at least one asset URL for ${platform}.`;
     }
 
-    if (!isValidUrl(assetUrl)) {
-      return `Enter a valid http or https asset URL for ${platform}.`;
+    for (const url of urls) {
+      const trimmedUrl = url.trim();
+      if (!trimmedUrl) {
+        return `Empty asset URL found for ${platform}.`;
+      }
+      if (!isValidUrl(trimmedUrl)) {
+        return `Enter a valid http or https asset URL for ${platform}.`;
+      }
     }
   }
 


### PR DESCRIPTION
- update assetUrls to handle arrays instead of single strings
- strip out checksums, sigs, and .txt files from the asset list
- add ui logic to add/remove multiple urls per platform
- fix go platform strings by appending -amd64
- handle platform mapping better when submitting the payload

Closes #13 