### PR TITLE
feat(ui): add theme variables and toggle support

### DIFF
--- a/app/generate/page.tsx
+++ b/app/generate/page.tsx
@@ -13,6 +13,7 @@ import { INITIAL_GO_RELEASE_DATA, type GoReleaseFormData } from "@/components/fo
 import { INITIAL_NPM_WRAPPER_DATA, type NpmWrapperFormData } from "@/components/forms/npm-wrapper-form";
 import { prefillFormData } from "@/lib/api";
 import { useAppContext, type DistributorType, type PrefillResponse } from "@/lib/app-context";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 function toUiPlatform(platform: string): string {
   const value = platform.toLowerCase();
@@ -186,14 +187,15 @@ export default function GeneratePage() {
   };
 
   return (
-    <div className="min-h-screen bg-zinc-950 text-zinc-100">
-      <header className="border-b border-zinc-800 px-4 py-4 sm:px-6">
+    <div className="min-h-screen text-[var(--foreground)]" style={{ background: "var(--background)" }}>
+      <header className="px-4 py-4 sm:px-6" style={{ borderBottom: "1px solid var(--header-border)" }}>
         <div className="flex items-center justify-between gap-4">
           <div className="flex items-center gap-3">
             <Button
               variant="ghost"
               size="sm"
-              className="h-8 px-2 text-zinc-400 hover:text-white"
+              className="h-8 px-2"
+              style={{ color: "var(--btn-ghost-text)" }}
               onClick={() => router.back()}
             >
               <ArrowLeft className="mr-2 h-4 w-4" />
@@ -202,28 +204,37 @@ export default function GeneratePage() {
             <h1 className="text-lg font-medium tracking-wide">DRB99</h1>
           </div>
 
-          <Button
-            onClick={handleContinue}
-            disabled={isContinuing || selectedDistributors.size === 0}
-            className="h-9 border border-zinc-100 bg-zinc-100 px-5 text-zinc-900 hover:bg-white disabled:opacity-40"
-          >
-            {isContinuing ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Prefilling...
-              </>
-            ) : (
-              "Continue"
-            )}
-          </Button>
+          <div className="flex items-center gap-3">
+            <ThemeToggle />
+            <Button
+              onClick={handleContinue}
+              disabled={Boolean(isContinuing || selectedDistributors.size === 0)}
+              className="h-9 px-5 transition-all duration-150 active:translate-x-[3px] active:translate-y-[3px] active:shadow-none disabled:opacity-40 disabled:shadow-none disabled:active:translate-x-0 disabled:active:translate-y-0"
+              style={{
+                background: "var(--btn-primary-bg)",
+                color: "var(--btn-primary-text)",
+                border: "1px solid var(--btn-primary-bg)",
+                boxShadow: `3px 3px 0px 0px var(--btn-primary-shadow)`,
+              }}
+            >
+              {isContinuing ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Prefilling...
+                </>
+              ) : (
+                "Continue"
+              )}
+            </Button>
+          </div>
         </div>
       </header>
 
       <main className="px-4 py-5 sm:px-6">
-        <Card className="border-zinc-800 bg-zinc-950 rounded-none">
+        <Card className="rounded-none" style={{ border: "1px solid var(--border)", background: "var(--card)" }}>
           <CardHeader className="pb-3">
-            <CardTitle className="text-sm font-medium uppercase tracking-wide text-zinc-300">Repository URL</CardTitle>
-            <CardDescription className="text-zinc-500">This URL is used for prefill and generation context.</CardDescription>
+            <CardTitle className="text-sm font-medium uppercase tracking-wide" style={{ color: "var(--muted-foreground)" }}>Repository URL</CardTitle>
+            <CardDescription style={{ color: "var(--muted-foreground)", opacity: 0.7 }}>This URL is used for prefill and generation context.</CardDescription>
           </CardHeader>
           <CardContent>
             <Label htmlFor="repo-url" className="sr-only">
@@ -237,21 +248,26 @@ export default function GeneratePage() {
                 setRepoUrl(event.target.value);
                 setError(null);
               }}
-              className="h-11 border-zinc-700 bg-zinc-900 text-zinc-100 placeholder:text-zinc-500 focus:border-zinc-400 focus:ring-0 rounded-none"
+              className="h-11 rounded-none focus:ring-0"
+              style={{
+                border: "1px solid var(--input)",
+                background: "var(--surface)",
+                color: "var(--foreground)",
+              }}
             />
           </CardContent>
         </Card>
 
         <section className="mt-6">
           <div className="mb-3 flex items-center justify-between">
-            <h2 className="text-sm font-medium uppercase tracking-wide text-zinc-300">Distributors</h2>
-            <p className="text-xs text-zinc-500">Select one or more targets</p>
+            <h2 className="text-sm font-medium uppercase tracking-wide" style={{ color: "var(--muted-foreground)" }}>Distributors</h2>
+            <p className="text-xs" style={{ color: "var(--muted-foreground)", opacity: 0.7 }}>Select one or more targets</p>
           </div>
           <DistributorSelector selected={selectedDistributors} onChange={toggleDistributor} />
         </section>
 
         {error && (
-          <div className="mt-5 border border-red-900 bg-red-950/40 px-4 py-3 text-sm text-red-300">
+          <div className="mt-5 px-4 py-3 text-sm" style={{ border: "1px solid var(--error-border)", background: "var(--error-bg)", color: "var(--error-text)" }}>
             {error}
           </div>
         )}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,8 +1,81 @@
 @import "tailwindcss";
 
+/* ── Light-mode tokens (default) ── */
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --muted: #f4f4f5;
+  --muted-foreground: #71717a;
+  --card: #ffffff;
+  --card-foreground: #171717;
+  --border: #e4e4e7;
+  --input: #e4e4e7;
+  --ring: #a1a1aa;
+  --accent: #f4f4f5;
+  --accent-foreground: #18181b;
+  --surface: #fafafa;
+  --surface-hover: #f4f4f5;
+  --header-border: #e4e4e7;
+  --badge-bg: rgba(0, 0, 0, 0.05);
+  --badge-text: #3f3f46;
+  --badge-border: rgba(0, 0, 0, 0.08);
+  --error-bg: #fef2f2;
+  --error-border: #fecaca;
+  --error-text: #b91c1c;
+  --warning-bg: #fffbeb;
+  --warning-border: #fde68a;
+  --warning-text: #92400e;
+  --btn-primary-bg: #18181b;
+  --btn-primary-text: #ffffff;
+  --btn-primary-hover: #27272a;
+  --btn-primary-shadow: rgba(24, 24, 27, 0.5);
+  --btn-ghost-text: #71717a;
+  --btn-ghost-hover: #18181b;
+  --sidebar-bg: #fafafa;
+  --sidebar-active: #f4f4f5;
+  --dot-generated: #10b981;
+  --dot-idle: #d4d4d8;
+  --editor-bg: #ffffff;
+  --code-header-bg: #f4f4f5;
+}
+
+/* ── Dark-mode tokens ── */
+.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+  --muted: #27272a;
+  --muted-foreground: #a1a1aa;
+  --card: #0a0a0a;
+  --card-foreground: #ededed;
+  --border: #27272a;
+  --input: #3f3f46;
+  --ring: #52525b;
+  --accent: #27272a;
+  --accent-foreground: #fafafa;
+  --surface: #18181b;
+  --surface-hover: #27272a;
+  --header-border: #27272a;
+  --badge-bg: rgba(255, 255, 255, 0.05);
+  --badge-text: #d4d4d8;
+  --badge-border: rgba(255, 255, 255, 0.1);
+  --error-bg: rgba(127, 29, 29, 0.3);
+  --error-border: #7f1d1d;
+  --error-text: #fca5a5;
+  --warning-bg: rgba(120, 53, 15, 0.3);
+  --warning-border: #78350f;
+  --warning-text: #fcd34d;
+  --btn-primary-bg: #f4f4f5;
+  --btn-primary-text: #18181b;
+  --btn-primary-hover: #ffffff;
+  --btn-primary-shadow: rgba(244, 244, 245, 0.7);
+  --btn-ghost-text: #a1a1aa;
+  --btn-ghost-hover: #ffffff;
+  --sidebar-bg: #0a0a0a;
+  --sidebar-active: #18181b;
+  --dot-generated: #34d399;
+  --dot-idle: #3f3f46;
+  --editor-bg: #1e1e1e;
+  --code-header-bg: #18181b;
 }
 
 @theme inline {
@@ -16,15 +89,103 @@ html {
   color-scheme: dark;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+html.light {
+  color-scheme: light;
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
   font-family: var(--font-geist-sans), sans-serif;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+/* ── Theme Toggle Button ── */
+.theme-toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: transparent;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  color: var(--muted-foreground);
+}
+
+.theme-toggle:hover {
+  background: var(--surface-hover);
+  color: var(--foreground);
+  border-color: var(--input);
+}
+
+.theme-toggle-sun,
+.theme-toggle-moon {
+  width: 18px;
+  height: 18px;
+  position: absolute;
+  transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1),
+              opacity 0.25s ease;
+}
+
+/* Dark mode: show moon, hide sun */
+.dark .theme-toggle-sun {
+  opacity: 0;
+  transform: rotate(-90deg) scale(0);
+}
+
+.dark .theme-toggle-moon {
+  opacity: 1;
+  transform: rotate(0deg) scale(1);
+}
+
+/* Light mode: show sun, hide moon */
+.light .theme-toggle-sun,
+:root:not(.dark) .theme-toggle-sun {
+  opacity: 1;
+  transform: rotate(0deg) scale(1);
+}
+
+.light .theme-toggle-moon,
+:root:not(.dark) .theme-toggle-moon {
+  opacity: 0;
+  transform: rotate(90deg) scale(0);
+}
+
+/* ── Light-mode overrides for form inputs with hardcoded dark classes ── */
+.light input,
+.light textarea,
+.light select {
+  background: var(--surface) !important;
+  color: var(--foreground) !important;
+  border-color: var(--input) !important;
+}
+
+.light input::placeholder,
+.light textarea::placeholder {
+  color: var(--muted-foreground) !important;
+  opacity: 0.6;
+}
+
+.light input:focus,
+.light textarea:focus,
+.light select:focus {
+  border-color: var(--ring) !important;
+}
+
+/* ── Platform macOS icon: invert only in dark mode ── */
+.dark .platform-icon-mac {
+  filter: invert(1);
+}
+
+.light .platform-icon-mac {
+  filter: none;
+}
+
+/* ── Light-mode label overrides for hardcoded zinc classes ── */
+.light label {
+  color: var(--muted-foreground) !important;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { AppProvider } from "@/lib/app-context";
+import { ThemeProvider } from "@/components/theme-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,10 +30,36 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${geistSans.variable} ${geistMono.variable} dark h-full antialiased`}
+      suppressHydrationWarning
     >
+      <head>
+        {/* Inline script to set theme class before React hydrates, preventing flash */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                try {
+                  var t = localStorage.getItem('drb99-theme');
+                  if (t === 'light' || t === 'dark') {
+                    document.documentElement.classList.remove('light', 'dark');
+                    document.documentElement.classList.add(t);
+                    document.documentElement.style.colorScheme = t;
+                  } else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+                    document.documentElement.classList.remove('dark');
+                    document.documentElement.classList.add('light');
+                    document.documentElement.style.colorScheme = 'light';
+                  }
+                } catch(e) {}
+              })();
+            `,
+          }}
+        />
+      </head>
       <body className="flex min-h-full flex-col">
-        <AppProvider>{children}</AppProvider>
+        <ThemeProvider>
+          <AppProvider>{children}</AppProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,32 +1,56 @@
+"use client";
+
 import Link from "next/link";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 export default function Home() {
   return (
-    <div className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-[#050505] font-sans selection:bg-zinc-800">
-      <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(ellipse_at_30%_40%,_rgba(255,255,255,0.06)_0%,_transparent_50%_,_rgba(0,0,0,0.9)_100%)]" />
+    <div
+      className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden font-sans selection:bg-zinc-800"
+      style={{ background: "var(--background)" }}
+    >
+      {/* Subtle radial gradient overlay */}
+      <div className="pointer-events-none absolute inset-0 -z-10 dark:bg-[radial-gradient(ellipse_at_30%_40%,_rgba(255,255,255,0.06)_0%,_transparent_50%_,_rgba(0,0,0,0.9)_100%)] bg-[radial-gradient(ellipse_at_30%_40%,_rgba(0,0,0,0.03)_0%,_transparent_50%)]" />
+
+      {/* Theme toggle – top right */}
+      <div className="absolute right-6 top-6 z-20">
+        <ThemeToggle />
+      </div>
 
       <main className="z-10 flex w-full max-w-5xl flex-col items-start justify-center px-8 md:px-12">
-        <div className="mb-8 inline-flex items-center rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-[11px] font-semibold tracking-widest text-zinc-300 backdrop-blur-md">
+        <div
+          className="mb-8 inline-flex items-center rounded-full px-3 py-1.5 text-[11px] font-semibold tracking-widest backdrop-blur-md"
+          style={{
+            border: "1px solid var(--badge-border)",
+            background: "var(--badge-bg)",
+            color: "var(--muted-foreground)",
+          }}
+        >
           GO CLI PACKAGING TOOL
         </div>
 
-        <h1 className="max-w-4xl tracking-tighter text-white">
+        <h1 className="max-w-4xl tracking-tighter" style={{ color: "var(--foreground)" }}>
           <span className="block text-5xl font-semibold sm:text-6xl md:text-7xl lg:text-[5.5rem] lg:leading-[1.05]">
             Build in Go.
           </span>
-          <span className="block text-5xl font-medium text-zinc-500 sm:text-6xl md:text-7xl lg:text-[5.5rem] lg:leading-[1.05]">
+          <span className="block text-5xl font-medium sm:text-6xl md:text-7xl lg:text-[5.5rem] lg:leading-[1.05]" style={{ color: "var(--muted-foreground)" }}>
             Ship with npm.
           </span>
         </h1>
 
-        <p className="mt-8 max-w-2xl text-lg leading-relaxed text-zinc-400 opacity-90 sm:text-xl md:text-[22px] md:leading-9">
+        <p className="mt-8 max-w-2xl text-lg leading-relaxed opacity-90 sm:text-xl md:text-[22px] md:leading-9" style={{ color: "var(--muted-foreground)" }}>
           Turn your Go binaries into installable npm packages with the release wiring already handled.
         </p>
 
         <div className="mt-12 flex w-full flex-col items-stretch gap-4 sm:flex-row sm:items-center sm:justify-start">
           <Link
             href="/generate"
-            className="group flex h-12 w-full sm:w-auto items-center justify-center gap-2.5 rounded-full bg-white px-8 text-sm font-semibold text-black shadow-[0_0_40px_-15px_rgba(255,255,255,0.5)] transition-all hover:scale-[1.02] hover:bg-zinc-200 active:scale-95 sm:h-14"
+            className="group flex h-12 w-full items-center justify-center gap-2.5 rounded-full px-8 text-sm font-semibold transition-all hover:scale-[1.02] active:scale-95 sm:h-14 sm:w-auto"
+            style={{
+              background: "var(--btn-primary-bg)",
+              color: "var(--btn-primary-text)",
+              boxShadow: "0 0 40px -15px var(--btn-primary-shadow)",
+            }}
           >
             Start Generating
             <svg
@@ -41,7 +65,12 @@ export default function Home() {
           </Link>
           <Link
             href="#"
-            className="flex h-12 w-full sm:w-auto sm:h-14 items-center justify-center rounded-full border border-white/10 bg-white/5 px-8 text-sm font-medium text-zinc-300 transition-all hover:bg-white/10 hover:text-white active:scale-95"
+            className="flex h-12 w-full items-center justify-center rounded-full px-8 text-sm font-medium transition-all active:scale-95 sm:h-14 sm:w-auto"
+            style={{
+              border: "1px solid var(--badge-border)",
+              background: "var(--badge-bg)",
+              color: "var(--muted-foreground)",
+            }}
           >
             Learn More
           </Link>

--- a/app/result/page.tsx
+++ b/app/result/page.tsx
@@ -14,6 +14,8 @@ import { generatePackage } from "@/lib/api";
 import { useAppContext, type DistributorType } from "@/lib/app-context";
 import { getDistributorLabel } from "@/components/forms/distributor-selector";
 import { mapPlatform, mapPlatformsList } from "@/lib/platforms";
+import { ThemeToggle } from "@/components/theme-toggle";
+import { useTheme } from "@/components/theme-provider";
 
 interface GeneratedResult {
   files: Record<string, string>;
@@ -314,7 +316,7 @@ function ResultPageContent() {
     }
 
     return (
-      <div className="border border-zinc-800 bg-zinc-900 p-4 text-sm text-zinc-400">
+      <div className="p-4 text-sm" style={{ border: "1px solid var(--border)", background: "var(--surface)", color: "var(--muted-foreground)" }}>
         GitHub Actions generator has no extra form fields. Use Generate to create workflow files.
       </div>
     );
@@ -322,8 +324,8 @@ function ResultPageContent() {
 
   if (!repoUrl || distributors.length === 0 || !activeDistributor) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-zinc-950">
-        <p className="text-zinc-500">Loading...</p>
+      <div className="flex min-h-screen items-center justify-center" style={{ background: "var(--background)" }}>
+        <p style={{ color: "var(--muted-foreground)" }}>Loading...</p>
       </div>
     );
   }
@@ -333,14 +335,15 @@ function ResultPageContent() {
   const selectedFile = currentViewState.activeFile || fileList[0] || "";
 
   return (
-    <div className="flex min-h-screen bg-zinc-950 text-zinc-100">
-      <aside className="w-64 shrink-0 border-r border-zinc-800">
-        <div className="flex h-12 items-center border-b border-zinc-800 px-3">
+    <div className="flex min-h-screen" style={{ background: "var(--background)", color: "var(--foreground)" }}>
+      <aside className="w-64 shrink-0" style={{ borderRight: "1px solid var(--border)", background: "var(--sidebar-bg)" }}>
+        <div className="flex h-12 items-center px-3" style={{ borderBottom: "1px solid var(--border)" }}>
           <Button
             variant="ghost"
             size="sm"
             onClick={() => router.push("/generate")}
-            className="h-8 px-2 text-zinc-400 hover:text-white"
+            className="h-8 px-2"
+            style={{ color: "var(--btn-ghost-text)" }}
           >
             <ArrowLeft className="mr-2 h-4 w-4" />
             Generate
@@ -356,12 +359,15 @@ function ResultPageContent() {
               <button
                 key={distributor}
                 onClick={() => handleSidebarSelect(distributor)}
-                className={`flex h-14 w-full items-center justify-between border-b border-zinc-800 px-4 text-left text-sm ${
-                  isActive ? "bg-zinc-900 text-zinc-100" : "bg-transparent text-zinc-300 hover:bg-zinc-900"
-                }`}
+                className="flex h-14 w-full items-center justify-between px-4 text-left text-sm transition-colors"
+                style={{
+                  borderBottom: "1px solid var(--border)",
+                  background: isActive ? "var(--sidebar-active)" : "transparent",
+                  color: isActive ? "var(--foreground)" : "var(--muted-foreground)",
+                }}
               >
                 <span>{getDistributorLabel(distributor)}</span>
-                <span className={`h-1.5 w-1.5 ${generated ? "bg-emerald-400" : "bg-zinc-700"}`} />
+                <span className="h-1.5 w-1.5" style={{ background: generated ? "var(--dot-generated)" : "var(--dot-idle)" }} />
               </button>
             );
           })}
@@ -369,13 +375,13 @@ function ResultPageContent() {
       </aside>
 
       <main className="flex min-w-0 flex-1 flex-col">
-        <header className="border-b border-zinc-800 px-5 py-3">
+        <header className="px-5 py-3" style={{ borderBottom: "1px solid var(--border)" }}>
           <div className="flex items-center justify-between gap-4">
             <div>
-              <h1 className="text-sm font-medium uppercase tracking-wide text-zinc-300">
+              <h1 className="text-sm font-medium uppercase tracking-wide" style={{ color: "var(--muted-foreground)" }}>
                 {getDistributorLabel(activeDistributor)}
               </h1>
-              <p className="text-xs text-zinc-500">{repoUrl}</p>
+              <p className="text-xs" style={{ color: "var(--muted-foreground)", opacity: 0.7 }}>{repoUrl}</p>
             </div>
 
             <div className="flex items-center gap-2">
@@ -385,16 +391,18 @@ function ResultPageContent() {
                     variant="ghost"
                     size="sm"
                     onClick={handleCopy}
-                    className="h-8 gap-2 border border-zinc-700 text-zinc-300 hover:text-white"
+                    className="h-8 gap-2"
+                    style={{ border: "1px solid var(--input)", color: "var(--muted-foreground)" }}
                   >
-                    {copied ? <Check className="h-4 w-4 text-emerald-400" /> : <Copy className="h-4 w-4" />}
+                    {copied ? <Check className="h-4 w-4" style={{ color: "var(--dot-generated)" }} /> : <Copy className="h-4 w-4" />}
                     {copied ? "Copied" : "Copy"}
                   </Button>
                   <Button
                     variant="ghost"
                     size="sm"
                     onClick={handleToggleEditing}
-                    className="h-8 gap-2 border border-zinc-700 text-zinc-300 hover:text-white"
+                    className="h-8 gap-2"
+                    style={{ border: "1px solid var(--input)", color: "var(--muted-foreground)" }}
                   >
                     {currentViewState.isEditing ? <Pencil className="h-4 w-4" /> : <Lock className="h-4 w-4" />}
                     {currentViewState.isEditing ? "Editing" : "Read only"}
@@ -403,7 +411,8 @@ function ResultPageContent() {
                     variant="ghost"
                     size="sm"
                     onClick={handleDownloadZip}
-                    className="h-8 gap-2 border border-zinc-700 text-zinc-300 hover:text-white"
+                    className="h-8 gap-2"
+                    style={{ border: "1px solid var(--input)", color: "var(--muted-foreground)" }}
                   >
                     <DownloadCloud className="h-4 w-4" />
                     Download
@@ -411,10 +420,17 @@ function ResultPageContent() {
                 </>
               )}
 
+              <ThemeToggle />
+
               <Button
                 onClick={handleGenerateCurrent}
                 disabled={isGenerating}
-                className="h-8 border border-zinc-100 bg-zinc-100 px-4 text-zinc-900 hover:bg-white disabled:opacity-40"
+                className="h-8 px-4 disabled:opacity-40"
+                style={{
+                  background: "var(--btn-primary-bg)",
+                  color: "var(--btn-primary-text)",
+                  border: "1px solid var(--btn-primary-bg)",
+                }}
               >
                 {isGenerating ? "Generating..." : hasResult ? "Regenerate" : "Generate"}
               </Button>
@@ -423,13 +439,13 @@ function ResultPageContent() {
         </header>
 
         {prefillIssue && (
-          <div className="border-b border-amber-900 bg-amber-950/30 px-5 py-2 text-xs text-amber-300">
+          <div className="px-5 py-2 text-xs" style={{ borderBottom: "1px solid var(--warning-border)", background: "var(--warning-bg)", color: "var(--warning-text)" }}>
             Prefill notice: {prefillIssue}
           </div>
         )}
 
         {error && (
-          <div className="border-b border-red-900 bg-red-950/30 px-5 py-2 text-xs text-red-300">{error}</div>
+          <div className="px-5 py-2 text-xs" style={{ borderBottom: "1px solid var(--error-border)", background: "var(--error-bg)", color: "var(--error-text)" }}>{error}</div>
         )}
 
         <section className="flex min-h-0 flex-1">
@@ -437,8 +453,8 @@ function ResultPageContent() {
             <div className="w-full overflow-auto p-5">{renderForm()}</div>
           ) : (
             <>
-              <div className="w-64 shrink-0 border-r border-zinc-800">
-                <div className="border-b border-zinc-800 px-4 py-2 text-xs uppercase tracking-wide text-zinc-500">
+              <div className="w-64 shrink-0" style={{ borderRight: "1px solid var(--border)" }}>
+                <div className="px-4 py-2 text-xs uppercase tracking-wide" style={{ borderBottom: "1px solid var(--border)", color: "var(--muted-foreground)" }}>
                   Files
                 </div>
                 <div>
@@ -446,11 +462,12 @@ function ResultPageContent() {
                     <button
                       key={filename}
                       onClick={() => handleSelectFile(filename)}
-                      className={`flex h-10 w-full items-center gap-2 border-b border-zinc-800 px-3 text-left text-sm ${
-                        selectedFile === filename
-                          ? "bg-zinc-900 text-zinc-100"
-                          : "text-zinc-300 hover:bg-zinc-900"
-                      }`}
+                      className="flex h-10 w-full items-center gap-2 px-3 text-left text-sm transition-colors"
+                      style={{
+                        borderBottom: "1px solid var(--border)",
+                        background: selectedFile === filename ? "var(--sidebar-active)" : "transparent",
+                        color: selectedFile === filename ? "var(--foreground)" : "var(--muted-foreground)",
+                      }}
                     >
                       <FileCode2 className="h-4 w-4" />
                       <span className="truncate">{filename}</span>
@@ -460,19 +477,11 @@ function ResultPageContent() {
               </div>
 
               <div className="min-w-0 flex-1">
-                <Editor
-                  height="100%"
-                  language={getLanguage(selectedFile)}
-                  theme="vs-dark"
-                  value={getCurrentFileContent(currentViewState, selectedFile)}
-                  onMount={handleEditorMount}
-                  onChange={currentViewState.isEditing ? handleEditorChange : undefined}
-                  options={{
-                    automaticLayout: true,
-                    minimap: { enabled: false },
-                    readOnly: !currentViewState.isEditing,
-                    fontSize: 13,
-                  }}
+                <ThemedEditor
+                  selectedFile={selectedFile}
+                  currentViewState={currentViewState}
+                  handleEditorMount={handleEditorMount}
+                  handleEditorChange={currentViewState.isEditing ? handleEditorChange : undefined}
                 />
               </div>
             </>
@@ -483,11 +492,42 @@ function ResultPageContent() {
   );
 }
 
+function ThemedEditor({
+  selectedFile,
+  currentViewState,
+  handleEditorMount,
+  handleEditorChange,
+}: {
+  selectedFile: string;
+  currentViewState: DistributorViewState;
+  handleEditorMount: OnMount;
+  handleEditorChange: ((value: string | undefined) => void) | undefined;
+}) {
+  const { theme } = useTheme();
+
+  return (
+    <Editor
+      height="100%"
+      language={getLanguage(selectedFile)}
+      theme={theme === "dark" ? "vs-dark" : "light"}
+      value={getCurrentFileContent(currentViewState, selectedFile)}
+      onMount={handleEditorMount}
+      onChange={handleEditorChange}
+      options={{
+        automaticLayout: true,
+        minimap: { enabled: false },
+        readOnly: !currentViewState.isEditing,
+        fontSize: 13,
+      }}
+    />
+  );
+}
+
 export default function ResultPage() {
   return (
     <React.Suspense
       fallback={
-        <div className="flex min-h-screen items-center justify-center bg-zinc-950 text-zinc-500">
+        <div className="flex min-h-screen items-center justify-center" style={{ background: "var(--background)", color: "var(--muted-foreground)" }}>
           Loading result view...
         </div>
       }

--- a/components/forms/aur-form.tsx
+++ b/components/forms/aur-form.tsx
@@ -26,6 +26,8 @@ interface AurFormProps {
   onChange: (data: AurFormData) => void;
 }
 
+const inputClasses = "h-auto px-4 py-3 rounded-none transition-all";
+
 export function AurForm({ data, onChange }: AurFormProps) {
   const safeData: AurFormData = {
     repoUrl: data.repoUrl ?? "",
@@ -43,69 +45,75 @@ export function AurForm({ data, onChange }: AurFormProps) {
     <div className="space-y-8">
       <div className="grid gap-6 sm:grid-cols-2">
         <div className="space-y-2.5">
-          <Label htmlFor="aur-repo-url" className="text-sm text-zinc-400">Repository URL</Label>
+          <Label htmlFor="aur-repo-url" className="text-sm" style={{ color: "var(--muted-foreground)" }}>Repository URL</Label>
           <Input
             id="aur-repo-url"
             placeholder="github.com/user/repo"
             value={safeData.repoUrl}
             onChange={(event) => update("repoUrl", event.target.value)}
-            className="h-auto bg-zinc-900/50 border-zinc-800 px-4 py-3 text-white rounded-none focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500"
+            className={inputClasses}
+            style={{ background: "var(--surface)", borderColor: "var(--border)", color: "var(--foreground)" }}
           />
         </div>
         <div className="space-y-2.5">
-          <Label htmlFor="aur-binary-name" className="text-sm text-zinc-400">Binary Name</Label>
+          <Label htmlFor="aur-binary-name" className="text-sm" style={{ color: "var(--muted-foreground)" }}>Binary Name</Label>
           <Input
             id="aur-binary-name"
             placeholder="mytool"
             value={safeData.binaryName}
             onChange={(event) => update("binaryName", event.target.value)}
-            className="h-auto bg-zinc-900/50 border-zinc-800 px-4 py-3 text-white rounded-none focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500"
+            className={inputClasses}
+            style={{ background: "var(--surface)", borderColor: "var(--border)", color: "var(--foreground)" }}
           />
         </div>
       </div>
 
       <div className="grid gap-6 sm:grid-cols-2">
         <div className="space-y-2.5">
-          <Label htmlFor="aur-version" className="text-sm text-zinc-400">Version</Label>
+          <Label htmlFor="aur-version" className="text-sm" style={{ color: "var(--muted-foreground)" }}>Version</Label>
           <Input
             id="aur-version"
             placeholder="v1.0.0"
             value={safeData.version}
             onChange={(event) => update("version", event.target.value)}
-            className="h-auto bg-zinc-900/50 border-zinc-800 px-4 py-3 text-white rounded-none focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500"
+            className={inputClasses}
+            style={{ background: "var(--surface)", borderColor: "var(--border)", color: "var(--foreground)" }}
           />
         </div>
         <div className="space-y-2.5">
-          <Label htmlFor="aur-license" className="text-sm text-zinc-400">License</Label>
+          <Label htmlFor="aur-license" className="text-sm" style={{ color: "var(--muted-foreground)" }}>License</Label>
           <Input
             id="aur-license"
             placeholder="MIT"
             value={safeData.license}
             onChange={(event) => update("license", event.target.value)}
-            className="h-auto bg-zinc-900/50 border-zinc-800 px-4 py-3 text-white rounded-none focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500"
+            className={inputClasses}
+            style={{ background: "var(--surface)", borderColor: "var(--border)", color: "var(--foreground)" }}
           />
         </div>
       </div>
 
       <div className="space-y-2.5">
-        <Label htmlFor="aur-description" className="text-sm text-zinc-400">Description</Label>
+        <Label htmlFor="aur-description" className="text-sm" style={{ color: "var(--muted-foreground)" }}>Description</Label>
         <textarea
           id="aur-description"
           placeholder="AUR package for mytool"
           value={safeData.description}
           onChange={(event) => update("description", event.target.value)}
           rows={6}
-          className={cn(
-            "w-full rounded-none border border-zinc-800 bg-zinc-900/50 px-4 py-3 text-sm text-white placeholder:text-zinc-500",
-            "transition-all resize-y focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
-          )}
+          className="w-full rounded-none border px-4 py-3 text-sm transition-all resize-y focus:outline-none focus:ring-1"
+          style={{
+            background: "var(--surface)",
+            borderColor: "var(--border)",
+            color: "var(--foreground)",
+          }}
         />
       </div>
 
-      <Separator className="bg-zinc-800" />
+      <Separator style={{ background: "var(--border)" }} />
 
-      <div className="space-y-2 text-xs text-zinc-500">
-        <p>AUR generation produces <span className="text-zinc-300">PKGBUILD</span> and <span className="text-zinc-300">.github/workflows/aur.yaml</span>.</p>
+      <div className="space-y-2 text-xs" style={{ color: "var(--muted-foreground)" }}>
+        <p>AUR generation produces <span style={{ color: "var(--foreground)" }}>PKGBUILD</span> and <span style={{ color: "var(--foreground)" }}>.github/workflows/aur.yaml</span>.</p>
         <p>Version is required because the package template is versioned off the repository tag.</p>
       </div>
     </div>

--- a/components/forms/distributor-selector.tsx
+++ b/components/forms/distributor-selector.tsx
@@ -46,12 +46,15 @@ export function DistributorSelector({ selected, onChange }: DistributorSelectorP
           <button
             key={distributor.id}
             onClick={() => onChange(distributor.id)}
-            className={cn(
-              "group flex min-h-32 flex-col justify-between border px-4 py-4 text-left transition-colors",
-              isSelected
-                ? "border-zinc-500 bg-zinc-900 text-zinc-100"
-                : "border-zinc-800 bg-zinc-950 text-zinc-100 hover:border-zinc-500"
-            )}
+            className="group flex min-h-32 flex-col justify-between border px-4 py-4 text-left transition-all duration-150 cursor-pointer active:translate-x-[3px] active:translate-y-[3px] active:shadow-none"
+            style={{
+              borderColor: isSelected ? "var(--ring)" : "var(--border)",
+              background: isSelected ? "var(--surface)" : "var(--card)",
+              color: "var(--foreground)",
+              boxShadow: isSelected
+                ? "3px 3px 0px 0px var(--ring)"
+                : "none",
+            }}
           >
             <div className="flex items-start justify-between gap-3">
               <img
@@ -63,27 +66,21 @@ export function DistributorSelector({ selected, onChange }: DistributorSelectorP
                 )}
               />
               <span
-                className={cn(
-                  "inline-block border px-1.5 py-0.5 text-[10px] uppercase tracking-wide",
-                  isSelected
-                    ? "border-zinc-500 text-zinc-300"
-                    : "border-zinc-700 text-zinc-500 group-hover:border-zinc-500"
-                )}
+                className="inline-block border px-1.5 py-0.5 text-[10px] uppercase tracking-wide"
+                style={{
+                  borderColor: isSelected ? "var(--ring)" : "var(--input)",
+                  color: "var(--muted-foreground)",
+                }}
               >
                 {isSelected ? "Selected" : "Select"}
               </span>
             </div>
 
             <div className="text-left">
-              <h3
-                className={cn(
-                  "text-sm font-medium transition-colors",
-                  isSelected ? "text-zinc-100" : "text-zinc-100"
-                )}
-              >
+              <h3 className="text-sm font-medium transition-colors" style={{ color: "var(--foreground)" }}>
                 {distributor.label}
               </h3>
-              <p className={cn("mt-1 text-xs", isSelected ? "text-zinc-400" : "text-zinc-500")}>
+              <p className="mt-1 text-xs" style={{ color: "var(--muted-foreground)" }}>
                 {distributor.description}
               </p>
             </div>

--- a/components/forms/go-release-form.tsx
+++ b/components/forms/go-release-form.tsx
@@ -21,6 +21,8 @@ interface GoReleaseFormProps {
   onChange: (data: GoReleaseFormData) => void;
 }
 
+const inputClasses = "py-3 px-4 h-auto rounded-none transition-all";
+
 export function GoReleaseForm({ data, onChange }: GoReleaseFormProps) {
   const update = <Key extends keyof GoReleaseFormData>(
     key: Key,
@@ -49,31 +51,33 @@ export function GoReleaseForm({ data, onChange }: GoReleaseFormProps) {
     <div className="space-y-8">
       <div className="grid gap-6 sm:grid-cols-2">
         <div className="space-y-2.5">
-          <Label htmlFor="go-repo-url" className="text-zinc-400 text-sm">Repository URL</Label>
+          <Label htmlFor="go-repo-url" className="text-sm" style={{ color: "var(--muted-foreground)" }}>Repository URL</Label>
           <Input
             id="go-repo-url"
             placeholder="github.com/user/repo"
             value={data.repoUrl}
             onChange={(event) => update("repoUrl", event.target.value)}
-            className="py-3 px-4 h-auto bg-zinc-900/50 border-zinc-800 focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500 text-white rounded-none transition-all"
+            className={inputClasses}
+            style={{ background: "var(--surface)", borderColor: "var(--border)", color: "var(--foreground)" }}
           />
         </div>
         <div className="space-y-2.5">
-          <Label htmlFor="go-binary-name" className="text-zinc-400 text-sm">Binary Name</Label>
+          <Label htmlFor="go-binary-name" className="text-sm" style={{ color: "var(--muted-foreground)" }}>Binary Name</Label>
           <Input
             id="go-binary-name"
             placeholder="mytool"
             value={data.binaryName}
             onChange={(event) => updateBinaryName(event.target.value)}
-            className="py-3 px-4 h-auto bg-zinc-900/50 border-zinc-800 focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500 text-white rounded-none transition-all"
+            className={inputClasses}
+            style={{ background: "var(--surface)", borderColor: "var(--border)", color: "var(--foreground)" }}
           />
         </div>
       </div>
 
-      <Separator className="bg-zinc-800/50" />
+      <Separator style={{ background: "var(--border)" }} />
 
       <div className="space-y-3">
-        <Label className="text-zinc-400 text-sm">Target Platforms</Label>
+        <Label className="text-sm" style={{ color: "var(--muted-foreground)" }}>Target Platforms</Label>
         <div className="grid grid-cols-3 gap-4">
           {PLATFORM_OPTIONS.map((platform) => {
             const isChecked = data.platforms.includes(platform.id);
@@ -90,17 +94,16 @@ export function GoReleaseForm({ data, onChange }: GoReleaseFormProps) {
                     togglePlatform(platform.id, !isChecked);
                   }
                 }}
-                className={cn(
-                  "group flex cursor-pointer flex-col items-center justify-center rounded-none border p-4 transition-all outline-none focus-visible:ring-2 focus-visible:ring-zinc-400",
-                  isChecked
-                    ? "border-zinc-400 bg-zinc-800/50"
-                    : "border-zinc-800 bg-transparent hover:border-zinc-700 hover:bg-zinc-900/30"
-                )}
+                className="group flex cursor-pointer flex-col items-center justify-center rounded-none border p-4 transition-all outline-none focus-visible:ring-2"
+                style={{
+                  borderColor: isChecked ? "var(--ring)" : "var(--border)",
+                  background: isChecked ? "var(--accent)" : "transparent",
+                }}
               >
                 {platform.id === "linux" && <img src="https://files.svgcdn.io/flat-color-icons/linux.svg" alt="Linux" className={cn("w-7 h-7 mb-3 transition-all", isChecked ? "opacity-100 drop-shadow-sm" : "opacity-50 grayscale group-hover:opacity-80 group-hover:grayscale-0")} />}
-                {platform.id === "darwin" && <img src="https://files.svgcdn.io/qlementine-icons/mac-16.svg" alt="macOS" className={cn("w-7 h-7 mb-3 transition-all", isChecked ? "opacity-100 drop-shadow-sm invert" : "opacity-50 grayscale invert group-hover:opacity-80")} />}
+                {platform.id === "darwin" && <img src="https://files.svgcdn.io/qlementine-icons/mac-16.svg" alt="macOS" className={cn("platform-icon-mac w-7 h-7 mb-3 transition-all", isChecked ? "opacity-100 drop-shadow-sm" : "opacity-50 grayscale group-hover:opacity-80")} />}
                 {platform.id === "windows" && <img src="https://files.svgcdn.io/devicon/windows8.svg" alt="Windows" className={cn("w-7 h-7 mb-3 transition-all", isChecked ? "opacity-100 drop-shadow-sm" : "opacity-50 grayscale group-hover:opacity-80 group-hover:grayscale-0")} />}
-                <span className={cn("text-xs font-medium transition-colors", isChecked ? "text-white" : "text-zinc-500 group-hover:text-zinc-300")}>{platform.label}</span>
+                <span className="text-xs font-medium transition-colors" style={{ color: isChecked ? "var(--foreground)" : "var(--muted-foreground)" }}>{platform.label}</span>
               </div>
             );
           })}

--- a/components/forms/npm-wrapper-form.tsx
+++ b/components/forms/npm-wrapper-form.tsx
@@ -33,6 +33,8 @@ interface NpmWrapperFormProps {
   onChange: (data: NpmWrapperFormData) => void;
 }
 
+const inputClasses = "py-3 px-4 h-auto rounded-none transition-all";
+
 export function NpmWrapperForm({ data, onChange }: NpmWrapperFormProps) {
   const safeData: NpmWrapperFormData = {
     repoUrl: data.repoUrl ?? "",
@@ -108,62 +110,67 @@ export function NpmWrapperForm({ data, onChange }: NpmWrapperFormProps) {
     <div className="space-y-8">
       <div className="grid gap-6 sm:grid-cols-3">
         <div className="space-y-2.5">
-          <Label htmlFor="npm-repo-url" className="text-zinc-400 text-sm">Repository URL</Label>
+          <Label htmlFor="npm-repo-url" className="text-sm" style={{ color: "var(--muted-foreground)" }}>Repository URL</Label>
           <Input
             id="npm-repo-url"
             placeholder="github.com/user/repo"
             value={safeData.repoUrl}
             onChange={(event) => update("repoUrl", event.target.value)}
-            className="py-3 px-4 h-auto bg-zinc-900/50 border-zinc-800 focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500 text-white rounded-none transition-all"
+            className={inputClasses}
+            style={{ background: "var(--surface)", borderColor: "var(--border)", color: "var(--foreground)" }}
           />
         </div>
         <div className="space-y-2.5">
-          <Label htmlFor="npm-cli-command" className="text-zinc-400 text-sm">Binary Name</Label>
+          <Label htmlFor="npm-cli-command" className="text-sm" style={{ color: "var(--muted-foreground)" }}>Binary Name</Label>
           <Input
             id="npm-cli-command"
             placeholder="mytool"
             value={safeData.cliCommandName}
             onChange={(event) => updateCommandName(event.target.value)}
-            className="py-3 px-4 h-auto bg-zinc-900/50 border-zinc-800 focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500 text-white rounded-none transition-all"
+            className={inputClasses}
+            style={{ background: "var(--surface)", borderColor: "var(--border)", color: "var(--foreground)" }}
           />
         </div>
         <div className="space-y-2.5">
-          <Label htmlFor="npm-version" className="text-zinc-400 text-sm">Version</Label>
+          <Label htmlFor="npm-version" className="text-sm" style={{ color: "var(--muted-foreground)" }}>Version</Label>
           <Input
             id="npm-version"
             placeholder="1.0.0"
             value={safeData.version}
             onChange={(event) => update("version", event.target.value)}
-            className="py-3 px-4 h-auto bg-zinc-900/50 border-zinc-800 focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500 text-white rounded-none transition-all"
+            className={inputClasses}
+            style={{ background: "var(--surface)", borderColor: "var(--border)", color: "var(--foreground)" }}
           />
         </div>
       </div>
 
       <div className="grid gap-6 sm:grid-cols-2">
         <div className="space-y-2.5">
-          <Label htmlFor="npm-package-name" className="text-zinc-400 text-sm">Package Name</Label>
+          <Label htmlFor="npm-package-name" className="text-sm" style={{ color: "var(--muted-foreground)" }}>Package Name</Label>
           <Input
             id="npm-package-name"
             placeholder="mytool-cli"
             value={safeData.packageName}
             onChange={(event) => update("packageName", event.target.value)}
-            className="py-3 px-4 h-auto bg-zinc-900/50 border-zinc-800 focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500 text-white rounded-none transition-all"
+            className={inputClasses}
+            style={{ background: "var(--surface)", borderColor: "var(--border)", color: "var(--foreground)" }}
           />
         </div>
         <div className="space-y-2.5">
-          <Label htmlFor="npm-license" className="text-zinc-400 text-sm">License (optional)</Label>
+          <Label htmlFor="npm-license" className="text-sm" style={{ color: "var(--muted-foreground)" }}>License (optional)</Label>
           <Input
             id="npm-license"
             placeholder="MIT"
             value={safeData.license}
             onChange={(event) => update("license", event.target.value)}
-            className="py-3 px-4 h-auto bg-zinc-900/50 border-zinc-800 focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500 text-white rounded-none transition-all"
+            className={inputClasses}
+            style={{ background: "var(--surface)", borderColor: "var(--border)", color: "var(--foreground)" }}
           />
         </div>
       </div>
 
       <div className="space-y-2.5">
-        <Label htmlFor="npm-description" className="text-zinc-400 text-sm">Description (optional)</Label>
+        <Label htmlFor="npm-description" className="text-sm" style={{ color: "var(--muted-foreground)" }}>Description (optional)</Label>
         <textarea
           id="npm-description"
           placeholder={
@@ -174,19 +181,20 @@ export function NpmWrapperForm({ data, onChange }: NpmWrapperFormProps) {
           value={safeData.description}
           onChange={(event) => update("description", event.target.value)}
           rows={6}
-          className={cn(
-            "w-full rounded-none border border-zinc-800 bg-zinc-900/50 px-4 py-3 text-sm text-white placeholder:text-zinc-500",
-            "focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500",
-            "transition-all resize-y"
-          )}
+          className="w-full rounded-none border px-4 py-3 text-sm transition-all resize-y focus:outline-none focus:ring-1"
+          style={{
+            background: "var(--surface)",
+            borderColor: "var(--border)",
+            color: "var(--foreground)",
+          }}
         />
       </div>
 
-      <Separator className="bg-zinc-800/50" />
+      <Separator style={{ background: "var(--border)" }} />
 
       <div className="space-y-6">
         <div className="space-y-3">
-          <Label className="text-zinc-400 text-sm">Target Platforms</Label>
+          <Label className="text-sm" style={{ color: "var(--muted-foreground)" }}>Target Platforms</Label>
           <div className="grid grid-cols-3 gap-4">
             {PLATFORM_OPTIONS.map((platform) => {
               const isChecked = safeData.platforms.includes(platform.id);
@@ -203,17 +211,16 @@ export function NpmWrapperForm({ data, onChange }: NpmWrapperFormProps) {
                       togglePlatform(platform.id, !isChecked);
                     }
                   }}
-                  className={cn(
-                    "group flex cursor-pointer flex-col items-center justify-center rounded-none border p-4 transition-all outline-none focus-visible:ring-2 focus-visible:ring-zinc-400",
-                    isChecked
-                      ? "border-zinc-400 bg-zinc-800/50"
-                      : "border-zinc-800 bg-transparent hover:border-zinc-700 hover:bg-zinc-900/30"
-                  )}
+                  className="group flex cursor-pointer flex-col items-center justify-center rounded-none border p-4 transition-all outline-none focus-visible:ring-2"
+                  style={{
+                    borderColor: isChecked ? "var(--ring)" : "var(--border)",
+                    background: isChecked ? "var(--accent)" : "transparent",
+                  }}
                 >
                   {platform.id === "linux" && <img src="https://files.svgcdn.io/flat-color-icons/linux.svg" alt="Linux" className={cn("w-7 h-7 mb-3 transition-all", isChecked ? "opacity-100 drop-shadow-sm" : "opacity-50 grayscale group-hover:opacity-80 group-hover:grayscale-0")} />}
-                  {platform.id === "darwin" && <img src="https://files.svgcdn.io/qlementine-icons/mac-16.svg" alt="macOS" className={cn("w-7 h-7 mb-3 transition-all", isChecked ? "opacity-100 drop-shadow-sm invert" : "opacity-50 grayscale invert group-hover:opacity-80")} />}
+                  {platform.id === "darwin" && <img src="https://files.svgcdn.io/qlementine-icons/mac-16.svg" alt="macOS" className={cn("platform-icon-mac w-7 h-7 mb-3 transition-all", isChecked ? "opacity-100 drop-shadow-sm" : "opacity-50 grayscale group-hover:opacity-80")} />}
                   {platform.id === "windows" && <img src="https://files.svgcdn.io/devicon/windows8.svg" alt="Windows" className={cn("w-7 h-7 mb-3 transition-all", isChecked ? "opacity-100 drop-shadow-sm" : "opacity-50 grayscale group-hover:opacity-80 group-hover:grayscale-0")} />}
-                  <span className={cn("text-xs font-medium transition-colors", isChecked ? "text-white" : "text-zinc-500 group-hover:text-zinc-300")}>{platform.label}</span>
+                  <span className="text-xs font-medium transition-colors" style={{ color: isChecked ? "var(--foreground)" : "var(--muted-foreground)" }}>{platform.label}</span>
                 </div>
               );
             })}
@@ -222,14 +229,14 @@ export function NpmWrapperForm({ data, onChange }: NpmWrapperFormProps) {
 
         {selectedPlatforms.length > 0 && (
           <div className="space-y-4 py-2">
-            <Label className="text-zinc-400 text-sm">Platform Asset URLs</Label>
+            <Label className="text-sm" style={{ color: "var(--muted-foreground)" }}>Platform Asset URLs</Label>
             <div className="space-y-5">
               {selectedPlatforms.map((platform) => {
                 const urls = safeData.assetUrls[platform.id] ?? [""];
 
                 return (
                   <div key={platform.id} className="space-y-2.5">
-                    <Label className="text-xs text-zinc-500 uppercase tracking-wide">
+                    <Label className="text-xs uppercase tracking-wide" style={{ color: "var(--muted-foreground)", opacity: 0.7 }}>
                       {platform.label}
                     </Label>
                     <div className="space-y-2">
@@ -241,13 +248,15 @@ export function NpmWrapperForm({ data, onChange }: NpmWrapperFormProps) {
                             onChange={(event) =>
                               updateAssetUrl(platform.id, index, event.target.value)
                             }
-                            className="py-2.5 px-4 h-auto bg-zinc-900/50 border-zinc-800 focus:border-zinc-500 focus:ring-1 focus:ring-zinc-500 text-white rounded-none transition-all flex-1"
+                            className="py-2.5 px-4 h-auto rounded-none transition-all flex-1"
+                            style={{ background: "var(--surface)", borderColor: "var(--border)", color: "var(--foreground)" }}
                           />
                           {urls.length > 1 && (
                             <button
                               type="button"
                               onClick={() => removeAssetUrl(platform.id, index)}
-                              className="shrink-0 flex items-center justify-center w-8 h-8 border border-zinc-800 text-zinc-500 hover:text-red-400 hover:border-red-800 transition-colors"
+                              className="shrink-0 flex items-center justify-center w-8 h-8 border transition-colors hover:text-red-500"
+                              style={{ borderColor: "var(--border)", color: "var(--muted-foreground)" }}
                               title="Remove URL"
                             >
                               <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -260,7 +269,8 @@ export function NpmWrapperForm({ data, onChange }: NpmWrapperFormProps) {
                       <button
                         type="button"
                         onClick={() => addAssetUrl(platform.id)}
-                        className="flex items-center gap-1.5 text-xs text-zinc-500 hover:text-zinc-300 transition-colors mt-1"
+                        className="flex items-center gap-1.5 text-xs transition-colors mt-1"
+                        style={{ color: "var(--muted-foreground)" }}
                       >
                         <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
                           <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import * as React from "react";
+
+type Theme = "light" | "dark";
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = React.createContext<ThemeContextType | undefined>(undefined);
+
+const STORAGE_KEY = "drb99-theme";
+
+function getInitialTheme(): Theme {
+  if (typeof window === "undefined") return "dark";
+
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === "light" || stored === "dark") return stored;
+
+  return window.matchMedia("(prefers-color-scheme: light)").matches
+    ? "light"
+    : "dark";
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = React.useState<Theme>("dark");
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    setTheme(getInitialTheme());
+    setMounted(true);
+  }, []);
+
+  React.useEffect(() => {
+    if (!mounted) return;
+
+    const root = document.documentElement;
+    root.classList.remove("light", "dark");
+    root.classList.add(theme);
+    root.style.colorScheme = theme;
+    localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme, mounted]);
+
+  const toggleTheme = React.useCallback(() => {
+    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+  }, []);
+
+  const value = React.useMemo(() => ({ theme, toggleTheme }), [theme, toggleTheme]);
+
+  return (
+    <ThemeContext.Provider value={value}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = React.useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+}

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "@/components/theme-provider";
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="theme-toggle"
+      aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+      title={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+    >
+      <Sun className="theme-toggle-sun" />
+      <Moon className="theme-toggle-moon" />
+    </button>
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -20,25 +20,31 @@ const buttonSizes = {
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: keyof typeof buttonVariants;
   size?: keyof typeof buttonSizes;
+  ref?: React.Ref<HTMLButtonElement>;
 }
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = "primary", size = "default", ...props }, ref) => {
-    return (
-      <button
-        className={cn(
-          "inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap transition-all focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-zinc-500 disabled:pointer-events-none disabled:opacity-50",
-          buttonVariants[variant],
-          buttonSizes[size],
-          className
-        )}
-        ref={ref}
-        {...props}
-      />
-    );
-  }
-);
-Button.displayName = "Button";
+function Button({
+  className,
+  variant = "primary",
+  size = "default",
+  disabled,
+  ref,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      {...props}
+      className={cn(
+        "inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap transition-all focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-zinc-500 disabled:pointer-events-none disabled:opacity-50",
+        buttonVariants[variant],
+        buttonSizes[size],
+        className
+      )}
+      ref={ref}
+      disabled={disabled ? true : undefined}
+    />
+  );
+}
 
 export { Button };
 export type { ButtonProps };

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -4,14 +4,20 @@ import { cn } from "@/lib/utils";
 export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
+  ({ className, type, style, ...props }, ref) => {
     return (
       <input
         type={type}
         className={cn(
-          "flex h-11 w-full rounded-none border border-white/10 bg-white/5 px-4 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-zinc-500 focus-visible:border-zinc-500 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-11 w-full rounded-none border px-4 py-2 text-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
+        style={{
+          background: "var(--surface)",
+          borderColor: "var(--border)",
+          color: "var(--foreground)",
+          ...style,
+        }}
         ref={ref}
         {...props}
       />

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -14,10 +14,11 @@ function Separator({
     <div
       role="separator"
       className={cn(
-        "shrink-0 bg-white/[0.08]",
+        "shrink-0",
         orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
         className
       )}
+      style={{ background: "var(--border)", ...props.style }}
       {...props}
     />
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
- switch from static zinc colors to theme-aware css variables on the generate page
- define light/dark tokens for everything from buttons to badges in globals.css
- add the ThemeToggle component to the header
- tweak button styles to include a nice shadow effect using the new tokens
- clean up some hardcoded styling to play better with the new theme system